### PR TITLE
Fix install-profile stickiness, wrong copilot package, and add external-skills lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,21 +67,23 @@ On macOS, Homebrew apps are installed from a templated `Brewfile` that respects 
 - personal: full set of apps (default)
 - restricted: minimal set for locked-down environments
 
-Select the profile via one of the following:
-
-1) Chezmoi data (persistent): edit `home/.chezmoidata/global.yaml`
+The profile is stored per machine in `~/.config/chezmoi/chezmoi.toml`, captured at `chezmoi init`. Set it once:
 
 ```
-profile: restricted
+DOTFILES_PROFILE=restricted chezmoi init --apply   # or answer the "Install profile" prompt
 ```
 
-2) Environment variable (one-off override):
+Every later `chezmoi apply` keeps that profile. To check: `chezmoi data | jq .profile`.
+
+The env var also works as a one-off override on any command:
 
 ```
 DOTFILES_PROFILE=restricted chezmoi apply
 ```
 
-The install script exports `DOTFILES_PROFILE` (env override wins, then chezmoi data; default is `personal`). The `Brewfile` gates heavier or personal-only apps (browsers, media, Ollama, Docker Desktop, etc.) under `personal`, while essential CLI tools remain for both.
+Be aware that a one-off override leaves the affected files differing from the stored target state, so the next plain `chezmoi apply` reverts them. Prefer changing the stored value (re-run `chezmoi init`, or edit `profile` in `~/.config/chezmoi/chezmoi.toml`).
+
+Profile-aware targets are `Brewfile` (personal-only casks: extra browsers, chat apps, media, games) and `.gitconfig` (commit email). Note that `brew bundle` never uninstalls, so switching to `restricted` stops installing personal apps but does not remove ones already present.
 
 ## 👏 Acknowledgements
 

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -13,10 +13,10 @@
 
 {{/* Default static values */}}
 
-{{ $gpgId := "TBD" }}
-{{ $agePubKey := "TBD" }}
-{{ $sshId := "TBD" }}
-
+{{ $profiles := list
+     "personal"
+     "restricted"
+}}
 {{ $themes := list
      "dark"
      "light"
@@ -53,10 +53,32 @@
 {{ $catppuccinLightFlavour := "latte" }}
 {{ $catppuccinDarkFlavour := "mocha" }}
 {{ $catppuccinAccentColor := "lavender" }}
-{{ $useHyde := false }}
 {{ $isLaptop := false }}
 {{ $shell = "zsh" }}
-{{ $tty := false }}
+
+{{/* Seed every prompted value from the config already on this machine, so that
+     re-running `chezmoi init` (even with --no-tty) preserves earlier answers
+     instead of silently resetting them to the defaults above. */}}
+{{- if hasKey . "terminalFontSize" }}{{ $terminalFontSize = .terminalFontSize }}{{ end }}
+{{- if hasKey . "theme" }}{{ $theme = .theme }}{{ end }}
+{{- if hasKey . "catppuccinLightFlavour" }}{{ $catppuccinLightFlavour = .catppuccinLightFlavour }}{{ end }}
+{{- if hasKey . "catppuccinDarkFlavour" }}{{ $catppuccinDarkFlavour = .catppuccinDarkFlavour }}{{ end }}
+{{- if hasKey . "catppuccinAccentColor" }}{{ $catppuccinAccentColor = .catppuccinAccentColor }}{{ end }}
+{{- if hasKey . "isLaptop" }}{{ $isLaptop = .isLaptop }}{{ end }}
+
+{{/* Install profile. Env var wins, otherwise the value already stored in
+     ~/.config/chezmoi/chezmoi.toml is kept, otherwise prompt (default personal).
+     Captured at `chezmoi init` so every later `chezmoi apply` stays on it. */}}
+{{ $profile := "personal" }}
+{{- if hasKey . "profile" }}{{ $profile = .profile }}{{ end }}
+{{- if env "DOTFILES_PROFILE" }}
+{{-   $profile = env "DOTFILES_PROFILE" }}
+{{- else if stdinIsATTY }}
+{{-   $profile = promptChoiceOnce . "profile" "Install profile" $profiles $profile }}
+{{- end }}
+{{- if not (has $profile $profiles) }}
+{{-   fail (printf "unknown profile %q, expected one of %s" $profile ($profiles | join ", ")) }}
+{{- end }}
 
 {{/* Pre auto */}}
 
@@ -68,22 +90,22 @@
 {{/* Prompts */}}
 
 {{ if stdinIsATTY }}
-  {{ $terminalFontSize = promptInt "Enter terminal font size" 13 }}
-  {{ $theme = promptChoice "Theme" $themes "dark" }}
-  {{ $catppuccinLightFlavour = promptChoice "Catppuccin flavor for light mode" $catppuccinFlavors "latte" }}
-  {{ $catppuccinDarkFlavour = promptChoice "Catppuccin flavor for dark mode" $catppuccinFlavors "mocha" }}
-  {{ $catppuccinAccentColor = promptChoice "Catppuccin accent color" $catppuccinAccentColors "lavender" }}
-  {{ if eq $osId "linux-arch" "linux-endeavouros" }}
-    {{ $useHyde = promptBool "Use Hyde" true }}
-  {{ end }}
+  {{ $terminalFontSize = promptIntOnce . "terminalFontSize" "Enter terminal font size" $terminalFontSize }}
+  {{ $theme = promptChoiceOnce . "theme" "Theme" $themes $theme }}
+  {{ $catppuccinLightFlavour = promptChoiceOnce . "catppuccinLightFlavour" "Catppuccin flavor for light mode" $catppuccinFlavors $catppuccinLightFlavour }}
+  {{ $catppuccinDarkFlavour = promptChoiceOnce . "catppuccinDarkFlavour" "Catppuccin flavor for dark mode" $catppuccinFlavors $catppuccinDarkFlavour }}
+  {{ $catppuccinAccentColor = promptChoiceOnce . "catppuccinAccentColor" "Catppuccin accent color" $catppuccinAccentColors $catppuccinAccentColor }}
 {{ end }}
 
-{{- $tty := "" -}}
-{{- if stdinIsATTY -}}
-{{-   $tty = true -}}
-{{- else -}}
-{{-   $tty = false -}}
-{{- end -}}
+{{/* Whether this machine is used interactively; gates the GitHub SSH rewrite in
+     ~/.gitconfig. Decided on first init (false in CI or a piped setup.sh) and
+     kept afterwards, so a later non-interactive init cannot silently drop it. */}}
+{{ $tty := false }}
+{{- if hasKey . "tty" }}
+{{-   $tty = .tty }}
+{{- else if stdinIsATTY }}
+{{-   $tty = true }}
+{{- end }}
 
 
 {{/* Semi prompts or auto */}}
@@ -112,7 +134,6 @@
 
 {{ $transparent := ne $opacity "1" }}
 
-encryption = "age" # or gpg
 mode = "file" # file, symlink
 progress = true
 
@@ -126,24 +147,14 @@ catppuccinDarkFlavour = {{ $catppuccinDarkFlavour | quote }}
 catppuccinFlavor = {{ $catppuccinFlavor | quote }}
 catppuccinFlavorTitle = {{ $catppuccinFlavor | title | quote }}
 catppuccinAccentColor = {{ $catppuccinAccentColor | quote }}
-gpgId = {{ $gpgId | quote }}
-sshId = {{ $sshId | quote }}
 osId = {{ $osId | quote }}
-useHyde = {{ $useHyde }}
+profile = {{ $profile | quote }}
 isLaptop = {{ $isLaptop }}
 tty = {{ $tty }}
 
 [data.catppuccin]
 accentColors = [ {{ $catppuccinAccentColors | quoteList | join ", " }} ]
 flavors = [ {{ $catppuccinFlavors | quoteList | join ", " }} ]
-
-[age]
-identity = "~/.age-key.txt"
-recipient = {{ $agePubKey | quote }}
-
-[gpg]
-recipient = {{ $gpgId | quote }}
-args = ["--quiet"]
 
 [git]
 autoAdd = true # Add changes to the source state after any change

--- a/home/.chezmoidata/global.yaml
+++ b/home/.chezmoidata/global.yaml
@@ -13,7 +13,3 @@ mise_plugins:
 - "https://github.com/rfrancis/asdf-gradle"
 - "https://github.com/asdf-community/asdf-kotlin"
 - "https://github.com/asdf-community/asdf-uv"
-
-# Profile controls what to install on macOS via Brewfile.
-# Allowed values: personal, restricted
-profile: personal

--- a/home/.chezmoidata/skills.yaml
+++ b/home/.chezmoidata/skills.yaml
@@ -1,0 +1,9 @@
+# Lockfile for third-party agent skills.
+# Canonical copy lands in ~/.agents/skills/<name>, symlinked into each agent dir.
+# Bump `sha` and run `chezmoi apply --refresh-externals` to update.
+# Removing an entry: delete it here and add the paths to .chezmoiremove.
+external_skills:
+  gh-stack:
+    repo: github/gh-stack
+    sha: 14fc42ed9b6c376a53b2f999f138d3bd26dac546
+    path: skills/gh-stack

--- a/home/.chezmoiexternals/skills.toml.tmpl
+++ b/home/.chezmoiexternals/skills.toml.tmpl
@@ -1,0 +1,9 @@
+# Generated from .chezmoidata/skills.yaml — edit that file, not this one.
+{{ range $name, $s := .external_skills }}
+[".agents/skills/{{ $name }}"]
+type = "archive"
+# pin: {{ $s.repo }}@{{ $s.sha }}
+url = "https://github.com/{{ $s.repo }}/archive/{{ $s.sha }}.tar.gz"
+include = ["*/{{ $s.path }}/**"]
+stripComponents = {{ add 1 (len (splitList "/" $s.path)) }}
+{{ end }}

--- a/home/.chezmoiignore.tmpl
+++ b/home/.chezmoiignore.tmpl
@@ -6,6 +6,7 @@
 .chezmoiscripts/linux/**
 {{ end }}
 
-{{ if ne .osId "darwin" }}
+{{ if ne .chezmoi.os "darwin" }}
 .chezmoiscripts/darwin/**
+Brewfile
 {{ end }}

--- a/home/.chezmoiscripts/darwin/run_onchange_after_bootstrap.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_after_bootstrap.sh.tmpl
@@ -49,16 +49,7 @@ install_brew_packages() {
     # Disable quarantine for casks
     export HOMEBREW_CASK_OPTS=--no-quarantine
 
-    # Determine install profile
-    export DOTFILES_PROFILE=${DOTFILES_PROFILE:-"{{ or .profile "personal" }}"}
-
     brew --version
-
-    # copilot-cli ships from the third-party aws/tap; Homebrew now refuses to
-    # load formulae from untrusted taps, which aborts the whole `brew bundle`
-    # run (including every formula after it, e.g. starship) unless trusted.
-    brew tap aws/tap >/dev/null 2>&1 || true
-    brew trust aws/tap || echo "brew trust aws/tap failed."
 
     if [ -f "${HOME}/Brewfile" ]; then
         brew bundle --file="${HOME}/Brewfile" || echo "brew bundle failed."

--- a/home/.chezmoiscripts/unix/run_onchange_after_20-link-external-skills.sh.tmpl
+++ b/home/.chezmoiscripts/unix/run_onchange_after_20-link-external-skills.sh.tmpl
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+{{ range $name, $s := .external_skills -}}
+# pin: {{ $s.repo }}@{{ $s.sha }}
+{{ end -}}
+skills=(
+{{ range $name, $_ := .external_skills }}  "{{ $name }}"
+{{ end }})
+
+if [ ${#skills[@]} -eq 0 ]; then
+  exit 0
+fi
+
+canonical="$HOME/.agents/skills"
+
+for name in "${skills[@]}"; do
+  if [ ! -d "$canonical/$name" ]; then
+    echo "external skill '$name' missing from $canonical — check its path in .chezmoidata/skills.yaml" >&2
+    exit 1
+  fi
+  for agent_dir in "$HOME/.claude/skills" "$HOME/.copilot/skills"; do
+    mkdir -p "$agent_dir"
+    ln -sfn "$canonical/$name" "$agent_dir/$name"
+  done
+done

--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -62,7 +62,9 @@ cask "docker-desktop"
 cask "ghostty"
 cask "alacritty"
 cask "claude-code"
-brew "copilot-cli"
+# GitHub Copilot CLI. Must stay a cask: the unqualified formula name resolves to
+# aws/tap/copilot-cli, which is AWS's unrelated container-deploy tool.
+cask "copilot-cli"
 brew "tmux"
 brew "herdr"
 brew "pnpm"

--- a/setup.sh
+++ b/setup.sh
@@ -207,12 +207,6 @@ function initialize_dotfiles() {
     run_chezmoi
 }
 
-function get_system_from_chezmoi() {
-    local system
-    system=$(chezmoi data | jq -r '.system')
-    echo "${system}"
-}
-
 function main() {
     echo "$DOTFILES_LOGO"
 


### PR DESCRIPTION
## Why

`DOTFILES_PROFILE=restricted chezmoi apply` was not sticky. The profile was read from the env at render time, and `.profile` came from committed `.chezmoidata/global.yaml`, so nothing recorded it per machine. Any plain `chezmoi apply` or `chezmoi update` on a restricted machine:

- rewrote `~/.gitconfig` back to the personal commit email
- rewrote `~/Brewfile` to the personal set
- and since that render is hashed into the darwin bootstrap, re-fired `brew bundle`, installing personal-only casks

This was live on one laptop: `~/Brewfile` and `~/.gitconfig` matched the restricted render while the target state said personal, so both were permanently dirty in `chezmoi status`. `chezmoi diff`/`status` were also misleading unless every invocation was prefixed with the env var.

While verifying, `brew "copilot-cli"` turned out to install the wrong tool.

## Changes

**Profile is now per machine.** Resolved once in the config template and baked into `[data]`. Precedence: `DOTFILES_PROFILE` → value stored in `~/.config/chezmoi/chezmoi.toml` → prompt → `personal`. Unknown values now fail loudly, since the consuming templates only compare against `"personal"` and a typo silently behaved as restricted. The env var still works as a one-off override.

**`chezmoi init` is no longer destructive.** The new flow tells you to re-run `init`, which previously reset theme, font size, catppuccin flavors and `isLaptop`, because those prompts weren't the `…Once` variants and nothing seeded from the existing config. Now seeded and `…Once`. `tty` keeps its first decision instead of flipping to `false` on a later non-interactive init and silently dropping the GitHub SSH rewrite.

**GitHub Copilot CLI vs AWS Copilot.** `brew "copilot-cli"` is a formula entry, and the unqualified formula name resolves to `aws/tap/copilot-cli` — AWS's container-deploy tool. Tapping and trusting `aws/tap` to unblock CI (6b19a1c) fixed the bundle by installing the wrong package, whose `copilot` binary also collides with the cask's. Now a cask, tap/trust workaround removed.

**External-skills lockfile.** Third-party agent skills are declared in `.chezmoidata/skills.yaml` (repo, commit sha, path); a templated archive external installs each to `~/.agents/skills/<name>`, and a `run_onchange` script symlinks them into `~/.claude/skills` and `~/.copilot/skills`. The pinned sha is the lock — no extra CLI, no mutable state file. Seeded with `github/gh-stack`.

The skills.sh CLI is good for discovery, but its lockfile isn't usable here: the global one at `~/.agents/.skill-lock.json` mixes in dismissed prompts and last-selected agents, and restore-from-lock is project-scope only, experimental, and skips hash verification.

**Docs and cleanup.** README's profile section was wrong on two points — it claimed the install script exports `DOTFILES_PROFILE` (it never mentions it) and that Ollama and Docker Desktop are personal-gated (they aren't). Also removed: `get_system_from_chezmoi` (never called, reads a `.system` key that doesn't exist), unused `gpgId`/`sshId`/`useHyde`, the `age`/`gpg` blocks configured with a `"TBD"` recipient that would fail on first use, a duplicate `$tty` declaration, and a dead `export DOTFILES_PROFILE` in the bootstrap. `Brewfile` is no longer written on Linux, and the darwin ignore rule now uses `.chezmoi.os` (`.osId` is `linux-<id>` on Linux).

## Verification

Profile resolution, against throwaway config paths:

| case | result |
|---|---|
| fresh init, no env | `personal` |
| `DOTFILES_PROFILE=restricted chezmoi init` | `restricted` |
| re-init, no env | keeps `restricted` |
| `DOTFILES_PROFILE=personal` re-init | flips to `personal` |
| `DOTFILES_PROFILE=restrictd` | fails: `unknown profile "restrictd", expected one of personal, restricted` |

- Init idempotency: a config hand-set to `theme=light, terminalFontSize=15, accent=flamingo, isLaptop=true, tty=true` survives `chezmoi init --no-tty` intact, with derived `catppuccinFlavor` correctly recomputed to `latte`.
- Live config regenerated from the template with all values held; `~/.gitconfig` and `~/Brewfile` no longer drift.
- `chezmoi cat`: restricted → work email + 24 casks; `DOTFILES_PROFILE=personal` → personal email + 35 casks.
- Wrong-package claim: `brew info --formula copilot-cli` → `aws/tap/copilot-cli` 1.34.1 (AWS), vs the installed cask, GitHub Copilot CLI 1.0.78.
- External skill applied end to end: `~/.agents/skills/gh-stack/{SKILL.md,references/*}` plus symlinks in both agent directories.
- `bash -n` clean on all three rendered chezmoi scripts. Bats suite 9/9.

## Notes for the reviewer

- The darwin bootstrap will re-run on the next full `chezmoi apply` because the Brewfile hash changed. That's what installs the correct copilot cask, but it also runs `brew upgrade`/`cleanup`.
- `aws/tap` is still tapped on the machine that ran the old workaround; `brew untap aws/tap` to clean up.
- Removing an external skill is deliberately manual via `.chezmoiremove`. Vendored skills in `dot_agents/skills` symlink into the same directory, so auto-pruning links that point there would delete them.
