### PR TITLE
Add worktrunk and wire it into the shell, Claude, and herdr

### DIFF
--- a/home/.chezmoiscripts/unix/run_onchange_after_30-install-herdr-plugins.sh.tmpl
+++ b/home/.chezmoiscripts/unix/run_onchange_after_30-install-herdr-plugins.sh.tmpl
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# herdr keeps plugins in ~/.config/herdr/plugins.json, which holds absolute paths
+# and resolved commits. chezmoi cannot manage that file, thus this script installs
+# the plugins. Bump the ref to update.
+
+if ! command -v herdr >/dev/null 2>&1; then
+  exit 0
+fi
+
+herdr plugin install devashish2203/herdr-worktrunk \
+  --ref a3107ca566bafcd463bc138007a0c01051970784 --yes

--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -67,6 +67,7 @@ cask "claude-code"
 cask "copilot-cli"
 brew "tmux"
 brew "herdr"
+brew "worktrunk"
 brew "pnpm"
 
 # SYSTEM TOOLS & SECURITY #

--- a/home/dot_bash_aliases
+++ b/home/dot_bash_aliases
@@ -33,6 +33,9 @@ alias kn='kubens'
 alias gp='git push'
 alias gpl='git pull'
 
+# Worktrees
+alias wsc='wt switch --create --execute=claude'
+
 # Code Editing
 alias pj='cd ${PROJECTS}'
 alias vimdiff='nvim -d'

--- a/home/dot_bashrc
+++ b/home/dot_bashrc
@@ -1,1 +1,3 @@
 export PATH=$HOME/.bin:$PATH
+
+if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init bash)"; fi

--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -54,12 +54,19 @@
   "skipWorkflowUsageWarning": true,
   "enabledPlugins": {
     "compound-engineering@compound-engineering-plugin": true,
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "worktrunk@worktrunk": true
   },
   "extraKnownMarketplaces": {
     "compound-engineering-plugin": {
       "source": {
         "repo": "EveryInc/compound-engineering-plugin",
+        "source": "github"
+      }
+    },
+    "worktrunk": {
+      "source": {
+        "repo": "max-sixty/worktrunk",
         "source": "github"
       }
     }

--- a/home/dot_config/worktrunk/config.toml
+++ b/home/dot_config/worktrunk/config.toml
@@ -1,0 +1,8 @@
+# https://worktrunk.dev/config/
+
+# Worktrees stay in the repository. The global gitignore holds `.worktrees/`.
+worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
+
+[list]
+# Pin the JSON output schema. A future release changes the default to 2.
+json-schema = 2

--- a/home/dot_config/zsh/dot_zshrc.tmpl
+++ b/home/dot_config/zsh/dot_zshrc.tmpl
@@ -59,3 +59,5 @@ fi
 # want in your public, versioned repo.
 # shellcheck disable=SC1090
 [ -f ~/.localrc ] && . ~/.localrc
+
+if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi

--- a/home/dot_gitignore_global
+++ b/home/dot_gitignore_global
@@ -109,3 +109,7 @@ coverage.txt
 ###
 # Claude
 **/.claude/settings.local.json
+
+###
+# Worktrunk
+.worktrees/


### PR DESCRIPTION
## TL;DR

The worktrunk installer edited `~/.bashrc` and `~/.config/zsh/.zshrc` directly, so the next `chezmoi apply` removes both lines. Brings the whole worktrunk setup under chezmoi: those shell lines, the brew formula, a user config, the Claude Code and herdr plugins, and a `wsc` alias.

**Files to review (8, +41 / -1):**

| File | Why |
|---|---|
| `home/dot_config/worktrunk/config.toml` *(start here)* | New user config. Worktrees go in `.worktrees/` in the repository. |
| `home/.chezmoiscripts/unix/run_onchange_after_30-install-herdr-plugins.sh.tmpl` | Installs the herdr plugin, pinned to a commit. |
| `home/dot_claude/settings.json.tmpl` | Declares the Claude Code plugin and its marketplace. |
| `home/dot_bashrc` and `home/dot_config/zsh/dot_zshrc.tmpl` | The shell init line the installer wrote. |
| `home/dot_bash_aliases` | `wsc` creates a worktree and starts claude in it. |
| `home/Brewfile.tmpl` | The `worktrunk` formula. |
| `home/dot_gitignore_global` | `.worktrees/`. |

## Reviewer notes

- **`config.toml` is not a template.** The file holds worktrunk `{{ }}` template syntax. A `.tmpl` suffix makes chezmoi render the file and fail.
- **The herdr plugin needs a script, not config.** herdr has no `[plugins]` config key. Its registry at `~/.config/herdr/plugins.json` holds absolute paths and resolved commits, which chezmoi must not own. The pinned ref matches how `skills.yaml` pins `gh-stack`. The script exits early without herdr, thus Linux stays clean.
- **No `_wt` completions file.** `wt config shell init` supplies the completions with the shell wrapper. The `.zshrc` runs `compinit` before that line, which worktrunk requires.
- `.worktrees/` goes in the global gitignore, which covers this machine only. A shared repository needs its own entry.

No `post-start` hook copies gitignored files such as `.env` into a new worktree. A blanket `wt step copy-ignored` also duplicates `node_modules` and build caches, thus the per-repository `--require-include` form comes later.

## Links

- [worktrunk.dev](https://worktrunk.dev/)
- [herdr-worktrunk plugin](https://github.com/devashish2203/herdr-worktrunk)
