### PR TITLE
Install diffnav from homebrew-core

### DIFF
--- a/home/.chezmoidata/homebrew.yaml
+++ b/home/.chezmoidata/homebrew.yaml
@@ -14,7 +14,6 @@ homebrew_trust:
   formulae:
     - argoproj/tap/kubectl-argo-rollouts # Argo Rollouts kubectl plugin
     - coleam00/archon/archon # Archon
-    - dlvhdr/formulae/diffnav # git diff viewer, used by the delta config
     - hashicorp/tap/nomad # HashiCorp Nomad
     - hashicorp/tap/packer # HashiCorp Packer
   taps:

--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -102,7 +102,7 @@ brew "btop"
 brew "yazi"
 brew "bat"
 brew "tealdeer"
-brew "dlvhdr/formulae/diffnav"
+brew "diffnav" # core formula. The dlvhdr tap pins a bad checksum for v0.12.0.
 
 # DEVELOPMENT TOOLS #
 brew "chezmoi"


### PR DESCRIPTION
## TL;DR

The `dlvhdr/formulae` tap pins SHA-256 `5fcc0c9…` for diffnav v0.12.0, but GitHub serves an asset that hashes to `2db8056…`, so `brew bundle` aborts and every MacOS run on `main` fails. Switches to the `homebrew-core` formula, which builds from the `v0.12.0` git tag and ships bottles for `arm64_sonoma`.

Every platform pin in that tap formula is stale (Linux x86_64 pins `a6fe16a…` against the actual `1531569…`), so waiting for it to self-heal needs a new upstream release. Core carries the same 0.12.0 version.

The trust-list entry goes away with it: `homebrew-core` is official, so Homebrew needs no trust grant.

- [Broken tap formula](https://github.com/dlvhdr/homebrew-formulae/blob/main/Formula/diffnav.rb)
