### PR TITLE
Add the typescript skill, with ultracite for linting

### DIFF
--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -61,7 +61,6 @@ cask "iina"
 cask "docker-desktop"
 cask "ghostty"
 cask "alacritty"
-cask "claude-code"
 # GitHub Copilot CLI. Must stay a cask: the unqualified formula name resolves to
 # aws/tap/copilot-cli, which is AWS's unrelated container-deploy tool.
 cask "copilot-cli"

--- a/home/dot_agents/skills/typescript/SKILL.md
+++ b/home/dot_agents/skills/typescript/SKILL.md
@@ -1,0 +1,367 @@
+---
+# source: https://github.com/SpillwaveSolutions/mastering-typescript-skill/tree/main/mastering-typescript (Richard Hightower, MIT)
+# source: https://github.com/cursor/plugins/tree/main/pstack/skills/typescript-best-practices (Cursor)
+name: typescript
+description: "Write, review, and configure TypeScript with strict types, no `any`/`as`/`!` escapes, and parsing at boundaries. Use for any .ts/.tsx/.mts work: type errors, type and signature design, tsconfig, Biome, Vitest, Zod, or a JavaScript migration."
+---
+
+# TypeScript
+
+Grounds the `principle-type-system-discipline` and `principle-boundary-discipline` skills in TypeScript
+syntax. Those skills say what to aim for in any typed language. This one says how TypeScript spells it,
+which compiler flags do the work for you, and where the language has sharp edges.
+
+The frame that makes the rest follow: **the type checker is a proof assistant, and every escape hatch is
+a proof you declined to write.** `any`, `as`, `!`, and `@ts-ignore` do not fix a type error. They move it
+to runtime, where it costs a postmortem instead of a compile.
+
+## Orient before you type
+
+TypeScript projects differ more than the language suggests. A pattern that is correct in one repo is a
+style violation in the next. So before the first edit:
+
+1. **Read `tsconfig.json`** (and whatever it extends). `strict`, `noUncheckedIndexedAccess`, and
+   `verbatimModuleSyntax` change what code is even legal. Writing `arr[0].name` is fine in one repo and a
+   compile error in another.
+2. **Read `package.json`.** The TypeScript version gates features in both directions: `satisfies` needs
+   4.9 and `erasableSyntaxOnly` needs 5.8, while TypeScript 7 — the native compiler — *removed* `baseUrl`,
+   `target: "ES5"`, `importsNotUsedAsValues`, and `preserveValueImports`. The runner, the module system,
+   and the validation library (Zod, Valibot, ArkType, class-validator, none) are decisions already made.
+3. **Read two or three neighbouring files.** Match the discriminant name, the error strategy, the
+   import style, the test layout. Consistency beats your preference.
+4. On an unfamiliar codebase, run `node scripts/ts-audit.mjs` from this skill for a fast read on
+   strictness gaps and escape-hatch density. See [Scripts](#scripts).
+
+**Do not tighten compiler flags in a repo you do not own.** Turning on `noUncheckedIndexedAccess` in a
+mature codebase yields hundreds of errors that have nothing to do with the task you were given. Report
+the gap, name the flag, let the owner schedule it. Suggest flags freely on a project you are creating.
+
+## The rules
+
+| Rule | Summary |
+|---|---|
+| Discriminated unions | Model variants with a literal discriminant (`kind`) so contradictory states cannot be written. No bags of optional fields. |
+| Branded types | Brand semantic primitives with `& { readonly __brand: "X" }` so a `UserId` cannot pass as an `OrderId`. Validate once at creation. |
+| Constructive modeling | Build the shape so the illegal value cannot be constructed: `[T, ...T[]]` for non-empty, `[T, T][]` for even length, `{ start, durationMs }` for a range. |
+| Simplest total type | Keep `T[]` while every operation on it stays total. Strengthen only where the loose type forces a `!`, a cast, or a "cannot happen" throw. |
+| `unknown` over `any` | External data is `unknown`. `any` disables checking for everything it touches, silently and transitively. |
+| No `as` casts | Cast only after the code has verified the claim. An unearned `as` is a runtime crash with a scheduled date. |
+| Narrowing hierarchy | Discriminant switch > `in` > `typeof` / `instanceof` > user-defined guard > `as`. Take the highest rung that works. |
+| Honest type guards | A guard must verify what its signature claims. A lying `isUser` is worse than `as` because the bug hides behind a reassuring name. |
+| Exhaustiveness | Put `const _exhaustive: never = x;` in the default arm so adding a variant breaks the build at every unhandled site. |
+| `satisfies` over `as` | `satisfies` checks the value against the type without widening the literals you want to keep. |
+| Parse at boundaries | Turn untrusted input into a named domain type at the edge. Trust the types inside. Never re-validate deep in the call chain. |
+| Derive, do not duplicate | Reach for `Pick` / `Omit` / `Parameters` / `ReturnType` / `Awaited` / `typeof` / `z.infer` before declaring a parallel interface. |
+| No floating promises | An unawaited promise swallows its rejection. Biome's `noFloatingPromises` catches much of what review does not. |
+| Literal unions over `enum` | An `enum` emits runtime code, is nominally typed, and cannot be stripped. A `const` object plus a literal union cannot. |
+| Object arguments | Pass an object, not four positional strings, so a swap is a compile error and the call site documents itself. Skip on hot paths. |
+| `readonly` at the edges | Mark inputs you do not mutate `readonly` / `ReadonlyArray<T>`. It documents intent and blocks accidental mutation of a caller's data. |
+| Two-line doc comments | Two lines, three if the invariant needs it. The signature states the contract, so a comment's only job is the why. A long one is a symptom — fix what it is telling you. |
+
+Worked examples for every row: `references/type-system.md` (narrowing, guards, `satisfies`, unions) and
+`references/patterns.md` (branding, errors, parsing, project layout).
+
+## Keep doc comments to two lines
+
+In an untyped language a doc comment carries the contract. In TypeScript the signature carries it and the
+compiler checks it, so a comment that describes shapes is a second, unchecked copy of something already
+true in the code. That leaves a doc comment one job: **the why the types cannot hold.**
+
+Two lines. Three when the invariant genuinely needs it. A nine-line header does not get read, goes stale
+invisibly because nothing checks it, and buries the one sentence that mattered.
+
+When a comment runs long, do not just truncate it — that trades verbosity for lost knowledge, which is the
+worse failure. Read the length as a diagnosis:
+
+| The comment explains… | The actual fix |
+|---|---|
+| When a field is set, or which field combinations are valid | A discriminated union. The comment wants to be a variant. |
+| That two arguments must not be swapped | Brand the types, or take an object argument. |
+| That input must be non-empty or in range | Construct the type so the bad value cannot exist. |
+| Four behaviours in one function | Three functions, each with a short comment. |
+| A whole subsystem's model | A doc or an ADR, linked in one line. |
+
+Then every fact that survives goes into the types, a name, a test, or a linked doc — in that order. A
+scope caveat like "this reads the daily track only" is a name asking to be more specific, not a sentence.
+
+What earns the three lines: a non-obvious invariant a reader would otherwise break, why the obvious
+implementation is wrong, a constraint from outside the codebase, or the reason a surviving `as` / `!` /
+`@ts-expect-error` is there. None of those describe what the code does.
+
+Worked cut of a real nine-line comment down to three, plus TSDoc tag guidance and when a published
+library's public API justifies more: `references/comments.md`.
+
+## Make illegal states unrepresentable
+
+The single highest-leverage habit. Booleans and optional fields multiply into states your code does not
+handle.
+
+```ts
+// Don't. loading + error + data = 8 combinations, 4 of them meaningless.
+type State = { loading: boolean; data?: User; error?: string };
+
+// Do. Three states exist, and the compiler hands you data only where it exists.
+type State =
+  | { kind: "loading" }
+  | { kind: "ready"; data: User }
+  | { kind: "error"; message: string };
+```
+
+The tell that a type is too loose: a bug makes you ask "wait, can that combination actually happen?", or
+you find yourself writing a comment to explain when a field is set. That comment wants to be a variant.
+
+Pick one discriminant name per codebase (`kind`, `type`, `tag`) and never mix them — mixed discriminants
+defeat the reader far more than they defeat the compiler.
+
+`{ completed: boolean; completedAt?: Date }` is the same bug in disguise. Derive the boolean from
+`completedAt !== null`, or split the variants.
+
+## Do not lie to the compiler
+
+```ts
+// Don't
+const user = JSON.parse(body) as User;      // no check ran; `user.email` may be undefined
+const first = items[0]!;                    // `!` asserts a fact you have not established
+// @ts-ignore                               // hides the next error too, forever
+
+// Do
+const user = UserSchema.parse(JSON.parse(body));  // the claim is now checked
+const first = items.at(0);                        // `T | undefined`, handled at the call site
+// @ts-expect-error react-19 types lag — remove after the bump
+```
+
+`@ts-expect-error` beats `@ts-ignore` because it fails the build once the underlying error goes away, so
+the suppression cannot outlive its reason. Always give the reason.
+
+When you must remove an existing `as`, diagnose why inference failed rather than reshuffling it:
+
+- **Missing discriminant** → add one and switch to a discriminated union.
+- **Source type too wide** (`Record<string, unknown>`, `unknown`) → narrow it or parse it.
+- **Untyped boundary** → add a parse function or a schema.
+- **Genuinely inexpressible** → a branded type or `satisfies`, with a comment saying why.
+
+Exhaustiveness is what keeps this honest as the code grows:
+
+```ts
+function label(s: Shape): string {
+  switch (s.kind) {
+    case "circle": return `circle r=${s.radius}`;
+    case "rect":   return `rect ${s.width}x${s.height}`;
+    default: {
+      const _exhaustive: never = s;   // adding a variant breaks the build here
+      return _exhaustive;
+    }
+  }
+}
+```
+
+Without that default arm, a new variant returns `undefined` at runtime and nothing tells you.
+
+## Parse at the boundary, trust inside
+
+Every value that crosses into the program is `unknown` until something checks it: HTTP bodies, query
+params, `JSON.parse`, `localStorage`, `postMessage`, IPC, environment variables, CLI args, file contents,
+third-party API responses, and database rows from an untyped driver.
+
+```ts
+const EnvSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  PORT: z.coerce.number().int().positive().default(3000),
+  NODE_ENV: z.enum(["development", "test", "production"]),
+});
+
+export const env = EnvSchema.parse(process.env);   // fails at boot, not at 3am
+export type Env = z.infer<typeof EnvSchema>;       // one source of truth
+```
+
+Two rules that carry most of the value:
+
+- **Derive the type from the schema** (`z.infer`), never hand-write a twin. A hand-written twin drifts,
+  and it drifts silently because both sides still compile.
+- **Parse once.** Re-validating three layers down says the types in between are not trusted, which means
+  they are decoration. If an inner function needs a guarantee, express it in its parameter type.
+
+Treat a third-party API response as hostile input, not as a typed client's word. It can change shape
+without notice, and its string fields can carry content you are about to render or feed to a model.
+
+`safeParse` where a bad value is an expected outcome you must report; `parse` where a bad value means the
+program is misconfigured and should die loudly.
+
+## Errors: pick one strategy per boundary
+
+```ts
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+```
+
+Use `Result` for **expected** failures the caller must handle — validation, a 404, a payment decline. The
+type forces the caller to deal with it, which is exactly what you want for a case that will happen daily.
+
+Throw for **unexpected** failures — a broken invariant, a missing config, a bug. Wrapping those in
+`Result` spreads noise through every signature on the path and buys nothing, because no caller has a
+sensible recovery.
+
+What matters more than the choice: **be consistent inside one module or boundary.** A codebase where
+some functions throw, some return `null`, and some return `{ error }` is unpredictable, and unpredictable
+is what causes the unhandled case.
+
+In `catch`, the variable is `unknown` (under `strict`). Narrow it before use — `err.message` on an
+`unknown` is a compile error for a good reason, because `throw "oops"` is legal JavaScript.
+
+## Async is where runtime bugs hide
+
+Types cannot see a promise you forgot to await, so let the linter help:
+
+```jsonc
+// biome.jsonc — these are type-aware, so they must be named individually
+"nursery": {
+  "noFloatingPromises": "error",   // silent unhandled rejection
+  "noMisusedPromises": "error"     // async fn passed where void is expected
+}
+```
+
+`noMisusedPromises` covers the case that surprises people: an `async` callback handed to something
+expecting `() => void` — an event handler, an `Array.prototype.forEach`, an Express middleware — throws
+into nothing. Express 4 in particular does not catch a rejected promise from a handler.
+
+**Do not treat the linter as the whole defense here.** Biome's type inference reads your own source,
+including across imports, but not the types in `lib.dom.d.ts` or `node_modules`. So
+`el.addEventListener("click", saveAsync)` — one of the cases where an unhandled rejection hurts most —
+goes unreported. Read every callback you hand to a framework or DOM API yourself.
+
+For deliberate fire-and-forget, say so at the call site: `void doTelemetry();`. That satisfies the rule
+and tells the next reader it was a decision.
+
+## Compiler settings that earn their keep
+
+`strict: true` is the floor, not the goal. The four that catch the most real bugs beyond it:
+
+| Flag | What it catches |
+|---|---|
+| `noUncheckedIndexedAccess` | `arr[i]` and `record[key]` become `T \| undefined`. Removes the single most common source of runtime `undefined`. |
+| `exactOptionalPropertyTypes` | Stops `{ a?: string }` accepting an explicit `a: undefined`, which a `key in obj` check treats as present. |
+| `noImplicitOverride` | A renamed base method silently orphans the subclass override without it. |
+| `noFallthroughCasesInSwitch` | A missing `break` reads as intentional to everyone except the compiler. |
+
+Also worth setting on a new project: `verbatimModuleSyntax` (import elision becomes explicit, so
+`import type` is required and side-effect imports survive), `isolatedModules`, `moduleDetection: "force"`,
+`noUncheckedSideEffectImports`, and `erasableSyntaxOnly` (TS 5.8+) if the code must run under a
+type-stripping runtime such as recent Node — that forbids `enum`, `namespace`, and constructor parameter
+properties, which cannot be erased.
+
+`tsc --init` writes most of this list already. Run it rather than hand-assembling a config.
+
+Start from `assets/tsconfig.strict.json` and `assets/biome.jsonc` on a new project. Biome lints and
+formats in one binary, so there is no Prettier and no linter-versus-formatter config to reconcile — but it
+does not replace `tsc`, which is still what proves your types. Full rationale per flag, the Biome rules
+worth enabling and the real limits of its type inference, plus Vite, Vitest, and pnpm wiring:
+`references/toolchain.md`.
+
+## Frameworks
+
+Read the relevant file rather than guessing at conventions — both frameworks have strong idioms that
+generic TypeScript advice gets wrong.
+
+- **React / Next.js** — `references/react.md`. Props, generic and polymorphic components, `useState` /
+  `useReducer` / `useRef` typing, event types, typed context, form handling.
+- **NestJS** — `references/nestjs.md`. DTOs and validation pipes, typed providers, repository types,
+  guards and decorators, exception filters.
+
+## Migrating JavaScript
+
+Incremental, always. A big-bang rewrite produces a branch nobody can review.
+
+1. `allowJs: true`, `checkJs: false`, `strict: true` — new code is strict from day one.
+2. Convert leaf modules first. A file with no local imports has no type surface to negotiate.
+3. Type a converted file honestly. `any` at the seams is fine and temporary; `any` in the domain model is
+   the thing you were trying to escape.
+4. Turn on one strict flag at a time and fix its fallout in its own commit. Mixed-cause commits are
+   unreviewable.
+5. JSDoc types work in `.js` files. Use them to buy safety in a file you are not ready to rename.
+
+Detail and CommonJS-to-ESM notes: `references/patterns.md`.
+
+## Common rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's just one `any`, I'll clean it up later" | `any` is contagious. Every value derived from it is unchecked too, and nothing marks the blast radius. |
+| "I know it's not null here" | Then the type should say so. If you cannot make it say so, you do not know it — you are guessing about a future caller. |
+| "The API always returns this shape" | Until it does not, and the failure surfaces three layers away from the cause. Parse it. |
+| "Enums are clearer than string unions" | An `enum` emits runtime code, is nominally typed, and blocks type-stripping runtimes. A `const` object plus a literal union reads the same and costs nothing. |
+| "I'll add types after it works" | Types are how you find out whether it works. Writing them last makes them describe the bugs. |
+| "`strict` is too noisy for this codebase" | Then adopt it per-flag, per-commit. "Too noisy" is a measure of how much is already unchecked. |
+| "The generic makes it reusable" | One caller needs no type parameter. Add the generic at the second caller, when you know what varies. |
+| "`interface` vs `type` doesn't matter" | It mostly doesn't — so follow the file you are in. Reach for `interface` when a consumer must augment it, `type` for unions and mapped types. |
+
+## Red flags
+
+- `any` outside a `.d.ts` shim, or `as` without a check above it
+- `!` non-null assertions, `@ts-ignore`, a `biome-ignore` with no reason comment
+- A `boolean` plus optional fields where a discriminated union belongs
+- A hand-written type that duplicates a Zod schema, a generated client, or a database row type
+- Validation repeated at three depths of the same call chain
+- `catch (err: any)` or `err.message` on an unnarrowed value
+- An `async` function passed where `() => void` is expected
+- A `switch` on a union with no exhaustiveness check
+- A type-level puzzle (nested conditionals, deep recursion) where a plain function would do
+- A doc comment over three lines, or one whose `@param` / `@returns` restate the signature
+- A callback declared with method syntax (`onChange(x: T): void`), which `strictFunctionTypes` skips
+
+## Verify before you claim it works
+
+Types compiling is not the same as code running. Do both.
+
+```bash
+npx tsc --noEmit          # or the project's `typecheck` script — proves the types
+npx biome check .         # lint + format; catches the promise bugs tsc does not model
+npm test                  # behaviour, not just shape
+```
+
+Biome is fast enough that skipping it is never the reason a check was left out. It is also not a
+substitute for `tsc` — the two do not overlap.
+
+- [ ] `tsc --noEmit` is clean — not "clean except the pre-existing errors" unless you say which
+- [ ] No new `any`, `as`, `!`, or `@ts-ignore`; each survivor has a comment saying why
+- [ ] Every union `switch` has an exhaustiveness check
+- [ ] External input is parsed once, at the boundary, into a named type
+- [ ] New errors follow the strategy already used at that boundary
+- [ ] No compiler flag changed unless that was the task
+- [ ] Type-level behaviour that matters is asserted, not assumed — `expectTypeOf` in Vitest, or a
+      deliberate `@ts-expect-error` proving the bad call is rejected
+- [ ] No doc comment runs past three lines, and none restates the signature
+
+## Reference files
+
+- `references/type-system.md` — annotations, `interface` vs `type`, unions, literal and template literal
+  types, narrowing, guards, assertion functions, `satisfies`, `any` / `unknown` / `never` / `void`,
+  variance and the method loophole
+- `references/generics.md` — constraints, defaults, `const` type params, mapped types, key remapping,
+  conditional types and `infer`, variadic tuples, the built-in utility types
+- `references/patterns.md` — `Result` and typed errors, Zod validation, branded types, project layout and
+  path aliases, barrel-file costs, JS-to-TS and CJS-to-ESM migration, typed env and security patterns
+- `references/comments.md` — the two-line doc-comment budget, where overflow belongs, a worked cut, TSDoc
+  tags worth writing
+- `references/react.md` — React and TypeScript
+- `references/nestjs.md` — NestJS and TypeScript
+- `references/toolchain.md` — tsconfig flags explained, TS 7 removals, Biome rules and the limits of its
+  type inference, Vitest, type tests, Vite, pnpm, publishing
+
+## Assets
+
+- `assets/tsconfig.strict.json` — strict baseline for a new project
+- `assets/biome.jsonc` — Biome lint and format config, with the type-aware rules enabled
+
+## Scripts
+
+- `scripts/ts-audit.mjs` — reports the effective strictness flags of a `tsconfig.json` (following
+  `extends`) and counts escape hatches in the source tree. Node only, no dependencies.
+
+```bash
+node <skill-dir>/scripts/ts-audit.mjs [path-to-project]
+```
+
+Run it to replace a guess with a measurement: which flags are off, and how much `any` / `as` / `!` /
+`@ts-ignore` the codebase already carries. That number decides whether "add types to this module" is a
+20-minute job or a migration.

--- a/home/dot_agents/skills/typescript/SKILL.md
+++ b/home/dot_agents/skills/typescript/SKILL.md
@@ -2,7 +2,7 @@
 # source: https://github.com/SpillwaveSolutions/mastering-typescript-skill/tree/main/mastering-typescript (Richard Hightower, MIT)
 # source: https://github.com/cursor/plugins/tree/main/pstack/skills/typescript-best-practices (Cursor)
 name: typescript
-description: "Write, review, and configure TypeScript with strict types, no `any`/`as`/`!` escapes, and parsing at boundaries. Use for any .ts/.tsx/.mts work: type errors, type and signature design, tsconfig, Biome, Vitest, Zod, or a JavaScript migration."
+description: "Write, review, and configure TypeScript with strict types, no `any`/`as`/`!` escapes, and parsing at boundaries. Use for any .ts/.tsx/.mts work: type errors, type and signature design, tsconfig, Ultracite or Biome linting, Vitest, Zod, or a JavaScript migration."
 ---
 
 # TypeScript
@@ -52,7 +52,7 @@ the gap, name the flag, let the owner schedule it. Suggest flags freely on a pro
 | `satisfies` over `as` | `satisfies` checks the value against the type without widening the literals you want to keep. |
 | Parse at boundaries | Turn untrusted input into a named domain type at the edge. Trust the types inside. Never re-validate deep in the call chain. |
 | Derive, do not duplicate | Reach for `Pick` / `Omit` / `Parameters` / `ReturnType` / `Awaited` / `typeof` / `z.infer` before declaring a parallel interface. |
-| No floating promises | An unawaited promise swallows its rejection. Biome's `noFloatingPromises` catches much of what review does not. |
+| No floating promises | An unawaited promise swallows its rejection. `noFloatingPromises` catches much of what review does not, but you must enable it yourself. |
 | Literal unions over `enum` | An `enum` emits runtime code, is nominally typed, and cannot be stripped. A `const` object plus a literal union cannot. |
 | Object arguments | Pass an object, not four positional strings, so a swap is a compile error and the call site documents itself. Skip on hot paths. |
 | `readonly` at the edges | Mark inputs you do not mutate `readonly` / `ReadonlyArray<T>`. It documents intent and blocks accidental mutation of a caller's data. |
@@ -214,7 +214,7 @@ In `catch`, the variable is `unknown` (under `strict`). Narrow it before use —
 Types cannot see a promise you forgot to await, so let the linter help:
 
 ```jsonc
-// biome.jsonc — these are type-aware, so they must be named individually
+// biome.jsonc — no Ultracite preset enables these, so name them yourself
 "nursery": {
   "noFloatingPromises": "error",   // silent unhandled rejection
   "noMisusedPromises": "error"     // async fn passed where void is expected
@@ -225,8 +225,9 @@ Types cannot see a promise you forgot to await, so let the linter help:
 expecting `() => void` — an event handler, an `Array.prototype.forEach`, an Express middleware — throws
 into nothing. Express 4 in particular does not catch a rejected promise from a handler.
 
-**Do not treat the linter as the whole defense here.** Biome's type inference reads your own source,
-including across imports, but not the types in `lib.dom.d.ts` or `node_modules`. So
+**Do not treat the linter as the whole defense here.** Ultracite sets about 365 rules and neither of these
+two is among them, because it avoids `nursery` rules on purpose. Biome's type inference reads your own
+source, including across imports, but not the types in `lib.dom.d.ts` or `node_modules`. So
 `el.addEventListener("click", saveAsync)` — one of the cases where an unhandled rejection hurts most —
 goes unreported. Read every callback you hand to a framework or DOM API yourself.
 
@@ -252,11 +253,12 @@ properties, which cannot be erased.
 
 `tsc --init` writes most of this list already. Run it rather than hand-assembling a config.
 
-Start from `assets/tsconfig.strict.json` and `assets/biome.jsonc` on a new project. Biome lints and
-formats in one binary, so there is no Prettier and no linter-versus-formatter config to reconcile — but it
-does not replace `tsc`, which is still what proves your types. Full rationale per flag, the Biome rules
-worth enabling and the real limits of its type inference, plus Vite, Vitest, and pnpm wiring:
-`references/toolchain.md`.
+Start from `assets/tsconfig.strict.json` and `assets/biome.jsonc` on a new project, or run
+`ultracite init`. Ultracite is the lint entry point: a preset over Biome that ships about 365 rules, the
+formatter, and a preset per framework, so there is no Prettier and no linter-versus-formatter config to
+reconcile. It does not replace `tsc`, which is still what proves your types. Full rationale per flag, the
+presets, the three rules Ultracite leaves out, and the real limits of Biome's type inference, plus Vite,
+Vitest, and pnpm wiring: `references/toolchain.md`.
 
 ## Frameworks
 
@@ -315,12 +317,13 @@ Types compiling is not the same as code running. Do both.
 
 ```bash
 npx tsc --noEmit          # or the project's `typecheck` script — proves the types
-npx biome check .         # lint + format; catches the promise bugs tsc does not model
+pnpm lint                 # `ultracite check`; catches the promise bugs tsc does not model
 npm test                  # behaviour, not just shape
 ```
 
-Biome is fast enough that skipping it is never the reason a check was left out. It is also not a
-substitute for `tsc` — the two do not overlap.
+Call the linter through the project's script. `ultracite check` spawns `biome` from `PATH`, and a package
+script is what puts `node_modules/.bin` there. It is fast enough that skipping it is never the reason a
+check was left out, and it is not a substitute for `tsc` — the two do not overlap.
 
 - [ ] `tsc --noEmit` is clean — not "clean except the pre-existing errors" unless you say which
 - [ ] No new `any`, `as`, `!`, or `@ts-ignore`; each survivor has a comment saying why
@@ -345,13 +348,14 @@ substitute for `tsc` — the two do not overlap.
   tags worth writing
 - `references/react.md` — React and TypeScript
 - `references/nestjs.md` — NestJS and TypeScript
-- `references/toolchain.md` — tsconfig flags explained, TS 7 removals, Biome rules and the limits of its
-  type inference, Vitest, type tests, Vite, pnpm, publishing
+- `references/toolchain.md` — tsconfig flags explained, TS 7 removals, the Ultracite presets and the rules
+  they leave out, the limits of Biome's type inference, Vitest, type tests, Vite, pnpm, publishing
 
 ## Assets
 
 - `assets/tsconfig.strict.json` — strict baseline for a new project
-- `assets/biome.jsonc` — Biome lint and format config, with the type-aware rules enabled
+- `assets/biome.jsonc` — Ultracite config: extends the core and type-aware presets, and adds the three
+  nursery rules no preset enables
 
 ## Scripts
 

--- a/home/dot_agents/skills/typescript/SKILL.md
+++ b/home/dot_agents/skills/typescript/SKILL.md
@@ -2,7 +2,7 @@
 # source: https://github.com/SpillwaveSolutions/mastering-typescript-skill/tree/main/mastering-typescript (Richard Hightower, MIT)
 # source: https://github.com/cursor/plugins/tree/main/pstack/skills/typescript-best-practices (Cursor)
 name: typescript
-description: "Write, review, and configure TypeScript with strict types, no `any`/`as`/`!` escapes, and parsing at boundaries. Use for any .ts/.tsx/.mts work: type errors, type and signature design, tsconfig, Ultracite or Biome linting, Vitest, Zod, or a JavaScript migration."
+description: "Write, review, and configure TypeScript with strict types, no `any`/`as`/`!` escapes, and parsing at boundaries. Use for any .ts/.tsx/.mts work: type errors, type and signature design, tsconfig, Ultracite or Biome linting, Vitest, Zod, or a JavaScript migration. Applies even when the ask sounds routine and never says TypeScript — 'add this function', 'fix this type error', 'make this build'."
 ---
 
 # TypeScript

--- a/home/dot_agents/skills/typescript/assets/biome.jsonc
+++ b/home/dot_agents/skills/typescript/assets/biome.jsonc
@@ -1,120 +1,77 @@
-// Biome config for a strict TypeScript project. Copy to the project root as
-// biome.jsonc, then delete what the project does not need.
+// Lint and format config for a strict TypeScript project. Ultracite is the
+// entry point, and Biome is the engine below it.
 //
-//   pnpm add -D --save-exact @biomejs/biome
-//   pnpm biome check --write .
+//   pnpm add -D --save-exact ultracite @biomejs/biome
+//   pnpm ultracite init      # writes this file, and detects your frameworks
+//   pnpm ultracite check     # read-only
+//   pnpm ultracite fix       # applies safe fixes
 //
-// Keep the .jsonc extension. Biome reads comments in biome.jsonc, but a comment
-// in biome.json makes it fall back to defaults WITHOUT reporting an error — your
-// severities and nursery rules stop applying and nothing tells you.
+// Ultracite MUST be a dev dependency, and not only an `npx ultracite` call.
+// Biome resolves `extends` from the project node_modules, thus a config that
+// extends a preset which is not installed fails to load.
 //
-// Biome replaces both the linter and the formatter, so there is no Prettier and
-// no eslint-config-prettier to reconcile. It does NOT replace `tsc`: Biome has
-// its own type inference, not a full type checker. Run `tsc --noEmit` too.
+// Run the CLI through a package script (`pnpm check`), and not as a bare
+// `./node_modules/.bin/ultracite check`. The CLI spawns `biome` from PATH,
+// which a package script supplies and a direct call does not.
+//
+// Commit a .gitignore before the first run. The core preset sets
+// vcs.useIgnoreFile, and Biome exits with a configuration error, not a warning,
+// when that is on and no ignore file exists. Nothing lints at all.
+//
+// Ultracite does NOT replace `tsc`. Biome has its own inference, not a full
+// type checker. Keep the `tsc --noEmit` gate.
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 
-  // Biome reads .gitignore, so ignore patterns live in one place. This errors
-  // out if no ignore file exists, which is why a new repo needs .gitignore
-  // before its first `biome check`.
-  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-
-  // Biome 2 replaced include/ignore with one `includes` list. A `!` prefix
-  // excludes. Order matters: later patterns win.
-  "files": {
-    "includes": ["**", "!**/dist/**", "!**/coverage/**", "!**/*.gen.ts"]
-  },
-
-  "formatter": {
-    "enabled": true,
-    // Biome defaults to tabs. Say what you want explicitly, or a teammate's
-    // editor and CI will disagree about the diff.
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineWidth": 100
-  },
-
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "double",
-      "semicolons": "always",
-      "trailingCommas": "all"
-    }
-  },
-
-  // Import sorting is an "assist action", not a lint rule, in Biome 2.
-  "assist": {
-    "actions": {
-      "source": { "organizeImports": "on" }
-    }
-  },
+  // `core` sets about 365 rules to error, and it also sets the formatter, the
+  // ignore globs, the import sorting, and the VCS integration. Do not restate
+  // any of that below. It already sets every rule that this skill argues for:
+  // noExplicitAny, noTsIgnore, noUnnecessaryConditions, noNonNullAssertion,
+  // noEnum, useImportType, and noUnusedVariables.
+  //
+  // `type-aware` adds the rules that need the project graph: noImportCycles,
+  // noUndeclaredDependencies, noUnresolvedImports, noPrivateImports, and
+  // noDeprecatedImports. `ultracite init --type-aware` adds it for you.
+  //
+  // Add a framework preset only for a framework the project has. The full set
+  // is angular, astro, jest, nestjs, next, qwik, react, remix, solid, svelte,
+  // tanstack, vitest, and vue.
+  //
+  //   "ultracite/biome/react"     "ultracite/biome/nestjs"
+  //   "ultracite/biome/vitest"    "ultracite/biome/next"
+  //
+  // Read the nestjs preset before you add it. It turns noEnum, noUselessConstructor,
+  // noStaticOnlyClass, and noParameterProperties OFF, because a decorator-driven
+  // framework needs each one. That is correct for NestJS, and it also means a
+  // NestJS project loses the "no enum" rule this skill recommends elsewhere.
+  "extends": ["ultracite/biome/core", "ultracite/biome/type-aware"],
 
   "linter": {
-    "enabled": true,
-
-    // Domains switch on rule sets that need extra context. `project` covers
-    // multi-file rules; `test` covers test-file rules. Biome infers these from
-    // your dependencies, so this block is mostly documentation.
-    //
-    // Note what a domain does NOT do: `"types": "all"` does not enable the
-    // nursery type-aware rules. Those must be named individually, below.
-    "domains": {
-      "project": "recommended",
-      "test": "recommended"
-    },
-
     "rules": {
-      "recommended": true,
-
-      "suspicious": {
-        "noExplicitAny": "error",
-        // `@ts-ignore` never expires. `@ts-expect-error` fails the build once
-        // the underlying error goes away, so it cannot outlive its reason.
-        "noTsIgnore": "error",
-        // A condition the types prove is always true. Either the check is dead
-        // or the type is wrong, and both are worth knowing. Needs inference.
-        "noUnnecessaryConditions": "error",
-        "noConfusingVoidType": "error",
-        "useAwait": "error"
-      },
-
-      "style": {
-        "noNonNullAssertion": "error",
-        // An enum emits runtime code, is nominally typed, and cannot be erased
-        // by a type-stripping runtime. Use a const object plus a literal union.
-        "noEnum": "error",
-        // Keeps type-only imports out of the runtime graph. Pairs with
-        // `verbatimModuleSyntax` in tsconfig.
-        "useImportType": "error",
-        "useConst": "error"
-      },
-
-      "correctness": {
-        "noUnusedVariables": "error",
-        "noUnusedFunctionParameters": "error",
-        "noUnusedImports": "error"
-      },
-
-      // Type-aware rules. Still nursery as of Biome 2.5, so they are opt-in by
-      // name and their behaviour can change between minors. They are the whole
-      // reason to bother with a linter on top of tsc — pin the Biome version
-      // (--save-exact) so a patch bump cannot change what CI rejects.
+      // The one real gap. Ultracite avoids nursery rules on purpose
+      // (haydenbleasel/ultracite#457), so no Ultracite preset enables these
+      // three, and `type-aware` does not either. They are the highest-value
+      // rules a linter adds on top of tsc, thus name them here.
+      //
+      // Pin Biome exactly (--save-exact). These are nursery, so a patch bump
+      // can change what CI rejects.
       "nursery": {
-        // The highest-value rule here: an unawaited promise swallows its
-        // rejection, so the failure vanishes instead of surfacing.
+        // An unawaited promise swallows its rejection, and the failure vanishes.
         "noFloatingPromises": "error",
-        // An async callback passed where `() => void` is expected — an event
-        // handler, a forEach. The rejection goes nowhere.
+        // An async callback passed where `() => void` is expected, such as an
+        // event handler or a forEach. The rejection goes nowhere.
         "noMisusedPromises": "error",
-        // The linter's version of the `never` default arm. Keep the `never`
-        // binding in the code too: it survives a lint config change.
+        // The linter version of the `never` default arm. Keep the `never`
+        // binding in the code too, because it survives a config change.
         "useExhaustiveSwitchCases": "error"
       }
     }
   },
 
-  // Tests run against real objects, so a cast in a fixture is cheap. Do not
-  // widen this to src/.
+  // Ultracite relaxes noExplicitAny for a `__tests__` directory only, and it
+  // never relaxes noNonNullAssertion. Add this block for colocated test files.
+  // A cast in a fixture is cheap, because a test runs against real objects.
+  // Do not widen this to src/.
   "overrides": [
     {
       "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts"],

--- a/home/dot_agents/skills/typescript/assets/biome.jsonc
+++ b/home/dot_agents/skills/typescript/assets/biome.jsonc
@@ -1,0 +1,129 @@
+// Biome config for a strict TypeScript project. Copy to the project root as
+// biome.jsonc, then delete what the project does not need.
+//
+//   pnpm add -D --save-exact @biomejs/biome
+//   pnpm biome check --write .
+//
+// Keep the .jsonc extension. Biome reads comments in biome.jsonc, but a comment
+// in biome.json makes it fall back to defaults WITHOUT reporting an error — your
+// severities and nursery rules stop applying and nothing tells you.
+//
+// Biome replaces both the linter and the formatter, so there is no Prettier and
+// no eslint-config-prettier to reconcile. It does NOT replace `tsc`: Biome has
+// its own type inference, not a full type checker. Run `tsc --noEmit` too.
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+
+  // Biome reads .gitignore, so ignore patterns live in one place. This errors
+  // out if no ignore file exists, which is why a new repo needs .gitignore
+  // before its first `biome check`.
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+
+  // Biome 2 replaced include/ignore with one `includes` list. A `!` prefix
+  // excludes. Order matters: later patterns win.
+  "files": {
+    "includes": ["**", "!**/dist/**", "!**/coverage/**", "!**/*.gen.ts"]
+  },
+
+  "formatter": {
+    "enabled": true,
+    // Biome defaults to tabs. Say what you want explicitly, or a teammate's
+    // editor and CI will disagree about the diff.
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+
+  // Import sorting is an "assist action", not a lint rule, in Biome 2.
+  "assist": {
+    "actions": {
+      "source": { "organizeImports": "on" }
+    }
+  },
+
+  "linter": {
+    "enabled": true,
+
+    // Domains switch on rule sets that need extra context. `project` covers
+    // multi-file rules; `test` covers test-file rules. Biome infers these from
+    // your dependencies, so this block is mostly documentation.
+    //
+    // Note what a domain does NOT do: `"types": "all"` does not enable the
+    // nursery type-aware rules. Those must be named individually, below.
+    "domains": {
+      "project": "recommended",
+      "test": "recommended"
+    },
+
+    "rules": {
+      "recommended": true,
+
+      "suspicious": {
+        "noExplicitAny": "error",
+        // `@ts-ignore` never expires. `@ts-expect-error` fails the build once
+        // the underlying error goes away, so it cannot outlive its reason.
+        "noTsIgnore": "error",
+        // A condition the types prove is always true. Either the check is dead
+        // or the type is wrong, and both are worth knowing. Needs inference.
+        "noUnnecessaryConditions": "error",
+        "noConfusingVoidType": "error",
+        "useAwait": "error"
+      },
+
+      "style": {
+        "noNonNullAssertion": "error",
+        // An enum emits runtime code, is nominally typed, and cannot be erased
+        // by a type-stripping runtime. Use a const object plus a literal union.
+        "noEnum": "error",
+        // Keeps type-only imports out of the runtime graph. Pairs with
+        // `verbatimModuleSyntax` in tsconfig.
+        "useImportType": "error",
+        "useConst": "error"
+      },
+
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUnusedFunctionParameters": "error",
+        "noUnusedImports": "error"
+      },
+
+      // Type-aware rules. Still nursery as of Biome 2.5, so they are opt-in by
+      // name and their behaviour can change between minors. They are the whole
+      // reason to bother with a linter on top of tsc — pin the Biome version
+      // (--save-exact) so a patch bump cannot change what CI rejects.
+      "nursery": {
+        // The highest-value rule here: an unawaited promise swallows its
+        // rejection, so the failure vanishes instead of surfacing.
+        "noFloatingPromises": "error",
+        // An async callback passed where `() => void` is expected — an event
+        // handler, a forEach. The rejection goes nowhere.
+        "noMisusedPromises": "error",
+        // The linter's version of the `never` default arm. Keep the `never`
+        // binding in the code too: it survives a lint config change.
+        "useExhaustiveSwitchCases": "error"
+      }
+    }
+  },
+
+  // Tests run against real objects, so a cast in a fixture is cheap. Do not
+  // widen this to src/.
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts"],
+      "linter": {
+        "rules": {
+          "style": { "noNonNullAssertion": "off" },
+          "suspicious": { "noExplicitAny": "off" }
+        }
+      }
+    }
+  ]
+}

--- a/home/dot_agents/skills/typescript/assets/tsconfig.strict.json
+++ b/home/dot_agents/skills/typescript/assets/tsconfig.strict.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    // Language and environment. Set `target` to the oldest runtime you support,
+    // not to the newest one you develop on. TypeScript 7 removed `target: ES5`.
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    // Every file is a module, so a file with no import is not a script in the
+    // global scope.
+    "moduleDetection": "force",
+
+    // The strict group. Never expand this into its individual flags: a future
+    // TypeScript release adds members, and an explicit list misses them.
+    "strict": true,
+
+    // Beyond `strict`. Each of these catches a class of real runtime bug.
+    // On an existing codebase, adopt them one per commit.
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUncheckedSideEffectImports": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // Module handling. `verbatimModuleSyntax` makes import elision explicit, so a
+    // type-only import must say `import type` and a side-effect import survives.
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+
+    // Unused-code checks. Set to false while migrating, so the signal is not lost
+    // in noise from code you have not reached yet.
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    // Output. Drop this block and set `"noEmit": true` when a bundler emits.
+    // `declaration` and `declarationMap` earn their build time only for a
+    // published library.
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    // One alias is usually enough, and it resolves relative to this file — do not
+    // add `baseUrl`, which TypeScript 7 removed. The runtime needs its own
+    // mapping: `vite-tsconfig-paths`, Jest `moduleNameMapper`, or the `imports`
+    // field in package.json.
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
+    // Performance. `skipLibCheck` hides genuine conflicts between two libraries'
+    // types; keep it on regardless, because the alternative is unusable.
+    "skipLibCheck": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsconfig.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/home/dot_agents/skills/typescript/evals/evals.json
+++ b/home/dot_agents/skills/typescript/evals/evals.json
@@ -57,29 +57,33 @@
     {
       "id": 5,
       "prompt": "Starting a new internal service from scratch — Node, Postgres, REST. Set me up with the TypeScript build, linting and tests so I don't have to think about it. We use pnpm.",
-      "expected_output": "A strict tsconfig, a Biome config with the type-aware rules named explicitly, Vitest, and package scripts wiring all three gates. Explains the few settings that matter rather than dumping config.",
+      "expected_output": "A strict tsconfig, an Ultracite lint config that also names the floating-promise nursery rules, Vitest, and package scripts wiring all three gates. Explains the few settings that matter rather than dumping config.",
       "files": [],
       "expectations": [
         "tsconfig enables `strict: true` plus flags beyond it, including `noUncheckedIndexedAccess`",
         "Uses NodeNext/nodenext module resolution for a Node service rather than bundler resolution",
-        "Uses Biome for both linting and formatting, and does not add ESLint or Prettier",
-        "Enables the type-aware rules by name under linter.rules.nursery (noFloatingPromises at minimum), not via a domains block alone",
-        "Package scripts cover all three gates separately: typecheck (tsc --noEmit), a biome check, and test",
-        "States that Biome does not replace tsc, so `tsc --noEmit` still runs",
+        "Uses Ultracite as the lint entry point, extending ultracite/biome/core rather than hand-writing a rule list",
+        "Installs ultracite as a dev dependency, not only as an npx invocation, since Biome resolves extends from node_modules",
+        "Names noFloatingPromises (at minimum) under linter.rules.nursery, because no Ultracite preset enables it",
+        "Does not restate rules ultracite/biome/core already sets, such as noExplicitAny or noNonNullAssertion",
+        "Package scripts cover all three gates separately: typecheck (tsc --noEmit), an ultracite check, and test",
+        "States that Ultracite and Biome do not replace tsc, so `tsc --noEmit` still runs",
         "Does not enable `emitDecoratorMetadata` / `experimentalDecorators` for a plain Node service that has no decorators"
       ]
     },
     {
       "id": 6,
-      "prompt": "We're ripping out ESLint and Prettier and moving to Biome across our TS monorepo. I already ran `biome migrate eslint --write` and it produced a biome.json. Can you review it and make sure we didn't lose anything important? I added a few comments in there explaining our rule choices.",
-      "expected_output": "Flags that comments in biome.json make Biome silently fall back to defaults (rename to biome.jsonc), checks whether the type-aware rules survived the migration, and notes that tsc is still required.",
+      "prompt": "We're ripping out ESLint and Prettier and moving to Ultracite across our TS monorepo. I already ran `biome migrate eslint --write` and it produced a biome.json with about 40 rules in it. I added a few comments in there explaining our rule choices. Can you review it and make sure we didn't lose anything important?",
+      "expected_output": "Flags that comments in biome.json make Biome silently fall back to defaults (rename to biome.jsonc), moves the config onto ultracite/biome/core instead of the hand-migrated rule list, points out that no preset enables the floating-promise rules, and notes that tsc is still required.",
       "files": [],
       "expectations": [
         "Identifies that comments in biome.json cause Biome to ignore the config silently, and says to rename it to biome.jsonc",
-        "Checks whether the type-aware rules (noFloatingPromises / noMisusedPromises) are enabled, since `biome migrate` does not add them",
-        "Notes that these rules are in the nursery group and must be named individually rather than switched on by a domain",
-        "States that Biome does not replace tsc and confirms a `tsc --noEmit` gate still exists",
-        "Mentions setting formatter.indentStyle explicitly rather than inheriting Biome's tab default",
+        "Moves the config to extend ultracite/biome/core rather than keeping the hand-migrated rule list, and says most of those 40 rules are already in the preset",
+        "Says ultracite must be a dev dependency, because Biome resolves extends from the project node_modules",
+        "Checks that noFloatingPromises / noMisusedPromises are named under linter.rules.nursery, since no Ultracite preset enables them",
+        "Notes that neither a `types` domain nor the ultracite/biome/type-aware preset switches those nursery rules on",
+        "States that Ultracite does not replace tsc and confirms a `tsc --noEmit` gate still exists",
+        "Does not tell the user to set formatter.indentStyle by hand once the config extends the preset, since core already sets it",
         "Recommends removing the leftover ESLint and Prettier config files and dependencies",
         "Does not claim rule parity with typescript-eslint without qualification"
       ]

--- a/home/dot_agents/skills/typescript/evals/evals.json
+++ b/home/dot_agents/skills/typescript/evals/evals.json
@@ -1,0 +1,102 @@
+{
+  "skill_name": "typescript",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Our order detail page has this state and we keep getting bug reports where the spinner and the error banner render at the same time: `const [loading, setLoading] = useState(false); const [order, setOrder] = useState<Order | null>(null); const [error, setError] = useState<string | null>(null);`. Can you add a retry button and clean this up while you're in there?",
+      "expected_output": "Replaces the three parallel state values with one discriminated union (or useReducer over one), so loading + error cannot both be true. Adds retry as a state transition. Explains why the union removes the bug class rather than adding a guard.",
+      "files": [],
+      "expectations": [
+        "Replaces the parallel boolean/nullable state with a single discriminated union carrying a literal discriminant (kind/type/status)",
+        "Names the impossible-state problem explicitly: the old shape allowed loading and error at once",
+        "Data is reachable only in the success variant, so the render cannot read a field that does not exist",
+        "Adds the retry as a transition of the same state model, not as a fourth independent state value",
+        "Does not introduce `any`, `as`, or a non-null assertion in the rewrite"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Add a POST /webhooks/stripe handler to our Express app that marks the matching order paid. I already wrote the type: `interface StripeEvent { id: string; type: string; data: { object: { metadata: { orderId: string }; amount_received: number } } }` and the other handlers just do `const event = req.body as StripeEvent`.",
+      "expected_output": "Parses the request body into the typed shape at the boundary instead of casting, and flags the cast pattern in the existing handlers. Treats webhook input as untrusted, including signature verification.",
+      "files": [],
+      "expectations": [
+        "Replaces `req.body as StripeEvent` with a runtime parse (schema library or an honest validating function) rather than reusing the cast",
+        "States why the cast is unsafe: nothing checked the shape, so the failure moves to runtime",
+        "Derives the TypeScript type from the schema (e.g. z.infer) instead of keeping a hand-written twin alongside it",
+        "Treats the webhook body as untrusted input and verifies the Stripe signature, not just the shape",
+        "Handles the async handler so a rejection cannot float (await plus try/catch, or an error-forwarding wrapper)"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Our tsconfig only has `strict: false` and there's `any` everywhere — about 40k lines across an Express API. Leadership wants us 'type safe'. Can you make the codebase strict?",
+      "expected_output": "Measures the current state first, then proposes a staged, per-flag, per-commit plan starting with `strict: true`. Does not flip every flag at once, and does not claim the migration is done after editing the config.",
+      "files": [],
+      "expectations": [
+        "Measures before changing: reads the existing tsconfig and counts the current `any` / `as` / escape-hatch load (running scripts/ts-audit.mjs counts)",
+        "Proposes a staged plan of one flag per commit rather than enabling everything in a single change",
+        "Sets `strict: true` as a group instead of listing its individual member flags",
+        "Names `noUncheckedIndexedAccess` as high value and warns it produces a large error volume on an existing codebase",
+        "Adds or confirms a `tsc --noEmit` CI gate so the ratchet cannot slip back",
+        "Does not claim the codebase is type safe merely because the config changed"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "tsc is blocking my deploy. Line 12 is `const email = users.find(u => u.id === id).email;` and it says \"Object is possibly 'undefined'\". Just stick a `!` on it or cast it, I know the user exists because we looked them up two lines earlier.",
+      "expected_output": "Declines the assertion and handles the undefined case honestly — or strengthens the type so the lookup cannot miss — while explaining that the earlier lookup does not prove anything to the compiler and unblocking the user in the same reply.",
+      "files": [],
+      "expectations": [
+        "Does not apply the requested `!` or `as` as the fix",
+        "Explains that the compiler cannot see the earlier lookup, so the assertion is an unverified claim that fails at runtime",
+        "Delivers a working alternative: handles the undefined branch, or changes the signature/data structure (e.g. a Map lookup or a non-empty type) so the value is guaranteed",
+        "Unblocks the deploy in the same reply rather than only lecturing",
+        "If a suppression is genuinely unavoidable, uses `@ts-expect-error` with a reason instead of `@ts-ignore` or `any`"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Starting a new internal service from scratch — Node, Postgres, REST. Set me up with the TypeScript build, linting and tests so I don't have to think about it. We use pnpm.",
+      "expected_output": "A strict tsconfig, a Biome config with the type-aware rules named explicitly, Vitest, and package scripts wiring all three gates. Explains the few settings that matter rather than dumping config.",
+      "files": [],
+      "expectations": [
+        "tsconfig enables `strict: true` plus flags beyond it, including `noUncheckedIndexedAccess`",
+        "Uses NodeNext/nodenext module resolution for a Node service rather than bundler resolution",
+        "Uses Biome for both linting and formatting, and does not add ESLint or Prettier",
+        "Enables the type-aware rules by name under linter.rules.nursery (noFloatingPromises at minimum), not via a domains block alone",
+        "Package scripts cover all three gates separately: typecheck (tsc --noEmit), a biome check, and test",
+        "States that Biome does not replace tsc, so `tsc --noEmit` still runs",
+        "Does not enable `emitDecoratorMetadata` / `experimentalDecorators` for a plain Node service that has no decorators"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "We're ripping out ESLint and Prettier and moving to Biome across our TS monorepo. I already ran `biome migrate eslint --write` and it produced a biome.json. Can you review it and make sure we didn't lose anything important? I added a few comments in there explaining our rule choices.",
+      "expected_output": "Flags that comments in biome.json make Biome silently fall back to defaults (rename to biome.jsonc), checks whether the type-aware rules survived the migration, and notes that tsc is still required.",
+      "files": [],
+      "expectations": [
+        "Identifies that comments in biome.json cause Biome to ignore the config silently, and says to rename it to biome.jsonc",
+        "Checks whether the type-aware rules (noFloatingPromises / noMisusedPromises) are enabled, since `biome migrate` does not add them",
+        "Notes that these rules are in the nursery group and must be named individually rather than switched on by a domain",
+        "States that Biome does not replace tsc and confirms a `tsc --noEmit` gate still exists",
+        "Mentions setting formatter.indentStyle explicitly rather than inheriting Biome's tab default",
+        "Recommends removing the leftover ESLint and Prettier config files and dependencies",
+        "Does not claim rule parity with typescript-eslint without qualification"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Add a function to our scheduler that returns the oldest instant any of a pipeline's daily sources still needs, or null when none has run. The tricky parts: sources advance independently so a stalled one widens the next run back to it; a source that has never run, or whose timestamp won't parse, should take whatever the others plan rather than dragging everyone back to the floor; and this only covers the daily track since backfills name their own range.",
+      "expected_output": "A small function whose doc comment is at most three lines, keeping only the non-obvious invariant. The scope caveat goes into the name, the contract stays in the signature, and the never-ran rule is covered by a test rather than a paragraph.",
+      "files": [],
+      "expectations": [
+        "The doc comment is at most three prose lines",
+        "The comment does not restate what the signature already says (the return type, or that it can be null)",
+        "No @param or @returns tags that merely repeat the parameter and return types",
+        "The daily-track scope is carried by the function name rather than by a sentence in the comment",
+        "The non-obvious rule is preserved somewhere — the never-ran/unparseable source not setting the floor is kept in the comment or covered by a test, not silently dropped",
+        "Does not move the dropped prose into a wall of inline comments inside the body instead"
+      ]
+    }
+  ]
+}

--- a/home/dot_agents/skills/typescript/references/comments.md
+++ b/home/dot_agents/skills/typescript/references/comments.md
@@ -1,0 +1,185 @@
+# Doc comments
+
+Companion to `SKILL.md`. How long a doc comment should be, and what to do with the knowledge that does
+not fit.
+
+- [The budget](#the-budget)
+- [Why TypeScript makes the budget tighter](#why-typescript-makes-the-budget-tighter)
+- [Length is a diagnosis, not a style preference](#length-is-a-diagnosis-not-a-style-preference)
+- [The four places overflow belongs](#the-four-places-overflow-belongs)
+- [A worked cut](#a-worked-cut)
+- [What earns three lines](#what-earns-three-lines)
+- [Inline comments](#inline-comments)
+- [TSDoc tags](#tsdoc-tags)
+
+## The budget
+
+**Two lines. Three when the invariant genuinely needs it. Never a wall.**
+
+That is not an aesthetic rule. A nine-line block above a function has three costs that compound:
+
+- **Nobody reads it.** A reader scanning for the call signature scrolls past the prose. The one sentence
+  that would have saved them is buried among eight that would not.
+- **It goes stale invisibly.** Nothing checks a comment. The longer it is, the more claims it makes, and
+  the more of those claims quietly stop being true. A stale comment is worse than no comment, because a
+  reader trusts it.
+- **It hides the real problem.** Long comments cluster on functions that do too much, on types too loose
+  to state their own contract, and on names that do not say what they mean. The comment is the symptom.
+
+## Why TypeScript makes the budget tighter
+
+In an untyped language a doc comment carries the contract: what goes in, what comes out, what can be null.
+In TypeScript the signature carries all of that, and the compiler checks it. So a comment that describes
+shapes is not just verbose — it is a second, unchecked copy of something already true in the code.
+
+```ts
+// Don't. Every line restates the signature, and the signature cannot drift from itself.
+/**
+ * Finds a user by id.
+ * @param id - the user's id, a string
+ * @param opts - options object, optional
+ * @returns a Promise of the User, or undefined if not found
+ */
+export async function findUser(id: UserId, opts?: FindOptions): Promise<User | undefined>
+```
+
+The signature already says all of it. Delete the comment; there was nothing in it.
+
+That leaves a doc comment exactly one job: **the why the types cannot hold.** A non-obvious invariant, a
+reason the obvious implementation is wrong, a constraint from outside the codebase. If you cannot name
+which of those you are writing, you are writing filler.
+
+## Length is a diagnosis, not a style preference
+
+When a comment runs long, do not reach for the delete key first. Ask what the length is telling you, and
+fix that:
+
+| The comment explains… | The actual fix |
+|---|---|
+| When a field is set, or which combination of fields is valid | A discriminated union. See `SKILL.md`. The comment wants to be a variant. |
+| That two parameters must not be swapped | Brand the types, or take an object argument. |
+| That the input must be non-empty, ordered, or in range | Construct the type so the bad value cannot exist — `NonEmpty<T>`, `{ start, durationMs }`. |
+| Four separate behaviours in one function | Two or three functions. Each one's comment is then short because each does one thing. |
+| What the function does, step by step | Better names, or extracted helpers whose names are the steps. |
+| A whole subsystem's model | A doc or an ADR. A function header is the wrong container for it. |
+
+Truncating without doing this loses real knowledge. That is the failure mode on the other side, and it is
+worse than verbosity — verbosity annoys a reader, deletion costs them the fact.
+
+## The four places overflow belongs
+
+When you cut a long comment, every load-bearing fact in it goes somewhere. In rough order of preference:
+
+1. **Into the types.** A variant, a brand, a non-empty tuple. Now the compiler enforces what the prose
+   asked for, and it cannot go stale.
+2. **Into a name.** `oldestPendingDailyInstant` carries "oldest", "pending", and "daily" for free. Scope
+   caveats especially belong here — a comment saying "this reads the daily track only" is a name asking to
+   be more specific.
+3. **Into a test.** "A source that has never run must not drag the others back" is a test case, and unlike
+   a sentence it fails when someone breaks it. Prefer this for any claim about behaviour.
+4. **Into a doc or ADR, linked by one line.** Subsystem models, historical decisions, and vendor quirks
+   are real knowledge that no function header can hold. `// see docs/pipeline-windows.md` is two words and
+   points at the whole story.
+
+What is left after those four is usually one sentence, and that sentence is worth reading.
+
+## A worked cut
+
+Before — nine lines of prose above a function:
+
+```ts
+/**
+ * The oldest instant any of a pipeline's daily sources still needs, or null
+ * when none has run.
+ *
+ * The sources advance independently, thus one that stalled on a day older than
+ * the others widens the next run back to it. The sources that already hold a
+ * planned day rewrite its key in place, which downstream dedup resolves. A
+ * source that has never run takes whatever the others plan, thus one new source
+ * does not drag every other source back to the floor. An unreadable stamp is
+ * named and ignored for the same reason.
+ *
+ * This reads the daily track only. A backfill names its own range.
+ */
+export function oldestNeeded(sources: Source[]): Date | null
+```
+
+Sort the claims by who needs them:
+
+- *Returns the oldest instant, or null when none has run* — the signature says this.
+- *Reads the daily track only* — the **name** should say this.
+- *A stalled source widens the run back to it* — the one non-obvious rule. **Keep.**
+- *A never-run source, and an unreadable stamp, are skipped rather than treated as the floor* — surprising,
+  and a plausible bug if someone "fixes" it. **Keep, compressed.**
+- *Sources holding a planned day rewrite the key in place, downstream dedup resolves it* — describes the
+  caller's machinery, not this function. **Move** to the dedup site.
+- *A backfill names its own range* — about a different code path. **Move** to the backfill entry point.
+
+After:
+
+```ts
+/**
+ * Sources advance independently, so the furthest-behind one sets the floor.
+ * A source that never ran, or whose stamp will not parse, is skipped rather
+ * than treated as the floor — one new source must not drag the rest back.
+ */
+export function oldestPendingDailyInstant(sources: Source[]): Date | null
+```
+
+Three lines. Nothing load-bearing was dropped: two claims moved to where they apply, two were already in
+the code, and the rename absorbed the scope caveat. If the never-ran rule matters as much as the prose
+suggested, it also wants a test — and then the comment could fall to two lines.
+
+## What earns three lines
+
+A short list, because the honest answer is "not much":
+
+- **A non-obvious invariant** a reader would otherwise break. The pipeline example above.
+- **Why the obvious implementation is wrong.** `// A Set here loses insertion order, which the wire
+  format depends on.` This is the highest-value comment there is: it stops a future refactor from
+  reintroducing a fixed bug.
+- **A constraint from outside the codebase.** A vendor's undocumented rate limit, a legacy column that
+  cannot be renamed, a spec requirement. Nothing in the repo can tell the reader this.
+- **A deliberate escape hatch.** Every surviving `as`, `!`, `@ts-expect-error`, or `biome-ignore` needs the
+  reason and, where possible, the condition for removing it.
+
+Notice that none of these describe what the code does. They all describe something the code cannot say.
+
+## Inline comments
+
+Same budget, one line, and the same test: does it say something the line below cannot?
+
+```ts
+// Don't
+// increment the counter
+count += 1;
+
+// Do
+// Stripe rounds half-up; Number.toFixed rounds half-even, which drifts by a cent per ~200 charges.
+const cents = Math.round(amount * 100);
+```
+
+A comment restating the next line is the version of this problem that is easiest to spot and delete.
+
+## TSDoc tags
+
+Use them where a tool consumes them, and not otherwise.
+
+Worth writing:
+
+- `@deprecated Use parseUser instead.` — editors surface it at every call site, so it does real work.
+- `@example` on a published library's public API, where the reader has no repo to grep.
+- `@throws` when throwing is part of the contract, since the return type cannot express it.
+
+Not worth writing:
+
+- `@param` and `@returns` that restate the types. In TypeScript this is duplication the compiler already
+  owns. Add `@param` only when the parameter's *meaning* is non-obvious in a way the name and type do not
+  cover — and prefer fixing the name.
+- `@public` / `@internal` on an app. The module's exports are the boundary. These matter for a published
+  library with an API-extractor step, and nowhere else.
+
+For a published library the calculus shifts: a consumer reads your `.d.ts` in a tooltip with no access to
+the implementation, so an `@example` and a real description on each public export are worth more lines than
+they would be internally. That is a reason to exceed the budget deliberately on the public surface, not a
+reason to abandon it everywhere.

--- a/home/dot_agents/skills/typescript/references/generics.md
+++ b/home/dot_agents/skills/typescript/references/generics.md
@@ -1,0 +1,228 @@
+# Generics reference
+
+Companion to `SKILL.md`. Read the section you need.
+
+- [When a generic is the right tool](#when-a-generic-is-the-right-tool)
+- [Constraints and defaults](#constraints-and-defaults)
+- [`const` type parameters](#const-type-parameters)
+- [Utility types](#utility-types)
+- [Mapped types](#mapped-types)
+- [Key remapping](#key-remapping)
+- [Conditional types and `infer`](#conditional-types-and-infer)
+- [Variadic tuples](#variadic-tuples)
+- [Knowing when to stop](#knowing-when-to-stop)
+
+## When a generic is the right tool
+
+A type parameter exists to **relate** two positions in a signature. If it appears once, it is doing
+nothing a plain type would not do.
+
+```ts
+// Pointless: T appears once, so this is `(x: unknown) => void`
+function log<T>(x: T): void { console.log(x); }
+
+// Earns it: the return type is tied to the argument type
+function first<T>(items: T[]): T | undefined { return items[0]; }
+
+// Earns it: two positions, related
+function pluck<T, K extends keyof T>(obj: T, key: K): T[K] { return obj[key]; }
+```
+
+Add the type parameter at the second caller, when you know what varies. Adding it at the first is a guess,
+and the guess usually names the wrong axis of variation.
+
+## Constraints and defaults
+
+```ts
+interface HasLength { length: number }
+
+function longest<T extends HasLength>(a: T, b: T): T {
+  return a.length >= b.length ? a : b;
+}
+
+longest("hi", "there");   // ok
+longest(1, 2);            // error: number has no length
+```
+
+`keyof` constraints are what make property access safe:
+
+```ts
+function pick<T, K extends keyof T>(obj: T, keys: readonly K[]): Pick<T, K> {
+  return Object.fromEntries(keys.map((k) => [k, obj[k]])) as Pick<T, K>;
+}
+
+pick(user, ["id", "email"]);   // { id: ...; email: ... }
+pick(user, ["emial"]);         // error: not a key of User
+```
+
+Defaults keep a generic out of the caller's way when the common case is one type:
+
+```ts
+interface ApiResponse<T = unknown> {
+  data: T;
+  status: number;
+}
+```
+
+Prefer a default of `unknown` over `any`, so an un-parameterized use still forces narrowing.
+
+## `const` type parameters
+
+TypeScript 5.0+. `const T` infers the literal types from an argument without the caller writing
+`as const`, which removes a papercut from list-shaped APIs.
+
+```ts
+function pickOne<const T extends readonly string[]>(opts: T): T[number] { ... }
+
+pickOne(["a", "b"]);   // returns "a" | "b", not string
+```
+
+Without `const`, the caller has to remember `["a", "b"] as const` at every call site, and forgetting it
+degrades the result to `string` silently.
+
+## Utility types
+
+Reach for these before declaring a new interface. A derived type cannot drift from its source; a
+hand-written twin will.
+
+| Type | Purpose |
+|---|---|
+| `Partial<T>` | All properties optional — patch and update inputs |
+| `Required<T>` | All properties required — a resolved config from an optional one |
+| `Readonly<T>` | All properties readonly (shallow) |
+| `Pick<T, K>` | Keep the named properties |
+| `Omit<T, K>` | Drop the named properties — `Omit<User, "passwordHash">` for an API response |
+| `Record<K, V>` | Object with typed keys and values |
+| `Exclude<T, U>` / `Extract<T, U>` | Filter a union |
+| `NonNullable<T>` | Drop `null` and `undefined` |
+| `ReturnType<F>` / `Parameters<F>` | Derive from an existing function |
+| `Awaited<T>` | Unwrap a promise, recursively |
+| `NoInfer<T>` | Block inference from this position (TS 5.4+), so another position decides |
+
+```ts
+type CreateUserInput = Omit<User, "id" | "createdAt">;   // one source of truth
+type UpdateUserInput = Partial<CreateUserInput>;
+type PublicUser = Omit<User, "passwordHash" | "resetToken">;
+```
+
+`Omit` on a sensitive field is a documentation habit worth adopting: the day someone adds `ssn` to
+`User`, an `Omit`-based response type leaks it, while a `Pick`-based one does not. Prefer `Pick` for
+anything that crosses a trust boundary — allowlists fail closed, denylists fail open.
+
+## Mapped types
+
+```ts
+type Nullable<T> = { [K in keyof T]: T[K] | null };
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+type Concrete<T> = { [K in keyof T]-?: T[K] };        // strips optionality
+```
+
+The `-` prefix removes a modifier; `+` (implicit) adds one. `-?` is how `Required` is built.
+
+A deep variant, useful for config and frozen state:
+
+```ts
+type DeepReadonly<T> = T extends (infer E)[]
+  ? readonly DeepReadonly<E>[]
+  : T extends object
+    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : T;
+```
+
+Watch the recursion depth. A deep mapped type over a large generated schema is a measurable compile-time
+cost, and the errors it produces are unreadable. If a type slows the editor, that is data — simplify it.
+
+## Key remapping
+
+The `as` clause in a mapped type renames keys.
+
+```ts
+type Getters<T> = {
+  [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
+};
+
+interface Person { name: string; age: number }
+type PersonGetters = Getters<Person>;   // { getName: () => string; getAge: () => number }
+```
+
+Mapping a key to `never` removes it, which is how you filter by value type:
+
+```ts
+type StringKeys<T> = {
+  [K in keyof T as T[K] extends string ? K : never]: T[K];
+};
+```
+
+## Conditional types and `infer`
+
+```ts
+type ElementOf<T> = T extends readonly (infer E)[] ? E : never;
+type Unwrap<T> = T extends Promise<infer R> ? R : T;
+
+type A = ElementOf<string[]>;      // string
+type B = Unwrap<Promise<User>>;    // User
+```
+
+Conditional types over a naked type parameter **distribute** across unions, which is the behaviour behind
+`Exclude`:
+
+```ts
+type ToArray<T> = T extends unknown ? T[] : never;
+type X = ToArray<string | number>;      // string[] | number[]
+
+// Wrap the parameter in a tuple to switch distribution off
+type ToArrayAll<T> = [T] extends [unknown] ? T[] : never;
+type Y = ToArrayAll<string | number>;   // (string | number)[]
+```
+
+Knowing that distinction saves an hour the first time a conditional type "mysteriously" returns a union.
+
+A practical pattern — deriving handler types from a schema:
+
+```ts
+type Handler<T> = T extends { kind: infer K; payload: infer P }
+  ? (kind: K, payload: P) => void
+  : never;
+```
+
+## Variadic tuples
+
+Tuples with spreads encode structural facts the type system can then enforce, which is the mechanism
+behind constructive modeling in `SKILL.md`.
+
+```ts
+type NonEmpty<T> = [T, ...T[]];
+type Pairs<T> = [T, T][];
+type WithId<T extends unknown[]> = [id: string, ...rest: T];
+
+const isNonEmpty = <T,>(a: readonly T[]): a is [T, ...T[]] => a.length > 0;
+```
+
+`NonEmpty<T>` is the single highest-value one: it turns "the caller must check for empty" from a comment
+into a compile error, and it deletes the `!` at the use site.
+
+```ts
+// Before: partiality smuggled past the compiler
+function newest(sessions: Session[]): Session { return sessions.at(0)!; }
+
+// After: the empty case lands at the call site, which is the only place that knows what empty means
+function newest(sessions: NonEmpty<Session>): Session { return sessions[0]; }
+```
+
+Named tuple members (`[id: string, ...rest: T]`) cost nothing and make the editor hint readable.
+
+## Knowing when to stop
+
+Type-level programming is genuinely powerful and its failure mode is expensive: a clever type produces
+error messages no one can act on, slows the language server for everyone in the repo, and hides the
+business logic behind puzzle-solving.
+
+Signals to back off:
+
+- The error message is longer than the function
+- You are testing the type by hovering rather than by reasoning
+- Recursion depth is doing real work (`Prettify`, deep path strings, arithmetic)
+- A runtime function plus a simple return type would give the same guarantee
+
+The strongest simplification is usually to move the constraint to runtime and parse: `z.infer` gives a
+precise type from a schema without a single conditional type, and the schema also validates.

--- a/home/dot_agents/skills/typescript/references/nestjs.md
+++ b/home/dot_agents/skills/typescript/references/nestjs.md
@@ -1,0 +1,295 @@
+# NestJS and TypeScript
+
+Companion to `SKILL.md`. NestJS is decorator-driven, which puts it at odds with a few of the general
+rules. Where they conflict, this file wins for Nest code — the framework's idiom is what the next
+maintainer will expect.
+
+- [Compiler settings Nest requires](#compiler-settings-nest-requires)
+- [DTOs and validation](#dtos-and-validation)
+- [Zod instead of class-validator](#zod-instead-of-class-validator)
+- [Providers and injection](#providers-and-injection)
+- [Repositories](#repositories)
+- [Typed configuration](#typed-configuration)
+- [Errors and exception filters](#errors-and-exception-filters)
+- [Guards and request typing](#guards-and-request-typing)
+- [Response shaping](#response-shaping)
+
+## Compiler settings Nest requires
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strictPropertyInitialization": false
+  }
+}
+```
+
+Three consequences worth knowing before you touch a Nest `tsconfig.json`:
+
+- **`emitDecoratorMetadata` means Nest code cannot run under a type-stripping runtime.** Node's built-in
+  TypeScript support and `erasableSyntaxOnly` both reject constructor parameter properties and metadata
+  emission. Nest needs `tsc` or SWC. Do not "modernize" this away.
+- **`strictPropertyInitialization: false` is the framework's escape hatch**, usually needed for
+  class-validator DTO fields. Prefer constructor parameter properties for dependencies — they are
+  initialized, so they need neither the flag nor a `!`.
+- **Decorator metadata reads the emitted type**, so a union or an interface type on a DTO field degrades to
+  `Object`. That is why class-validator DTOs use classes and concrete types.
+
+## DTOs and validation
+
+```ts
+import { IsEmail, IsString, MinLength, IsOptional } from "class-validator";
+
+export class CreateUserDto {
+  @IsString()
+  @MinLength(2)
+  name!: string;
+
+  @IsEmail()
+  email!: string;
+
+  @IsOptional()
+  @IsString()
+  bio?: string;
+}
+```
+
+Wire the global pipe, and set all three options:
+
+```ts
+app.useGlobalPipes(
+  new ValidationPipe({
+    whitelist: true,             // strip properties with no decorator
+    forbidNonWhitelisted: true,  // reject them instead, so a typo is an error not a silent drop
+    transform: true,             // produce a real DTO instance, not a plain object
+  }),
+);
+```
+
+`whitelist: true` is the one that matters for security. Without it, extra body properties survive into
+your service, and a `Object.assign(entity, dto)` becomes mass assignment — a client sets `role: "admin"`
+and the validator never objected because it never looked.
+
+`transform: true` is what makes `@Type(() => Number)` and DTO methods work. Without it you have a plain
+object wearing a class type, which is exactly the lie the type system is supposed to prevent.
+
+## Zod instead of class-validator
+
+Prefer Zod on a new Nest service, unless the codebase already standardized on class-validator. One
+schema gives you the runtime check and the type, with no decorator metadata and no `!` on every field.
+
+```ts
+export const CreateUserSchema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+  bio: z.string().optional(),
+});
+export type CreateUserDto = z.infer<typeof CreateUserSchema>;
+```
+
+```ts
+@Injectable()
+export class ZodValidationPipe<T> implements PipeTransform<unknown, T> {
+  constructor(private readonly schema: z.ZodType<T>) {}
+
+  transform(value: unknown): T {
+    const result = this.schema.safeParse(value);
+    if (!result.success) {
+      throw new BadRequestException({ code: "VALIDATION_ERROR", details: result.error.flatten() });
+    }
+    return result.data;
+  }
+}
+
+@Post()
+create(@Body(new ZodValidationPipe(CreateUserSchema)) dto: CreateUserDto) { ... }
+```
+
+The tradeoff to accept knowingly: Swagger generation via `@nestjs/swagger` reads decorator metadata, so a
+Zod DTO needs `nestjs-zod` or a hand-written `@ApiBody` to appear in the generated OpenAPI document. Pick
+class-validator if generated API docs are a hard requirement and you do not want the extra dependency.
+
+Do not run both. Two validation systems on one endpoint means two places to update and one of them will be
+forgotten.
+
+## Providers and injection
+
+Constructor parameter properties, `private readonly`:
+
+```ts
+@Injectable()
+export class UserService {
+  constructor(
+    private readonly users: UserRepository,
+    private readonly logger: Logger,
+  ) {}
+
+  async findOne(id: UserId): Promise<User> {
+    const user = await this.users.findById(id);
+    if (user === null) throw new NotFoundException(`user ${id} not found`);
+    return user;
+  }
+}
+```
+
+This is the one place where positional constructor arguments are correct — Nest resolves them by type, not
+by position, so the "pass an object" rule does not apply.
+
+For an interface-typed dependency, the interface has no runtime token, so provide one explicitly:
+
+```ts
+export const MAILER = Symbol("MAILER");
+
+@Module({
+  providers: [{ provide: MAILER, useClass: SesMailer }],
+})
+export class MailModule {}
+
+constructor(@Inject(MAILER) private readonly mailer: Mailer) {}
+```
+
+A `Symbol` token beats a string token: a typo in a string is a runtime resolution failure at first request,
+while a `Symbol` import is a compile error.
+
+## Repositories
+
+Keep the persistence type separate from the domain type. They diverge — nullable columns, join rows,
+snake_case names — and merging them pushes the database's shape into your business logic.
+
+```ts
+export interface UserRepository {
+  findById(id: UserId): Promise<User | null>;
+  create(input: CreateUserDto): Promise<User>;
+  update(id: UserId, patch: Partial<CreateUserDto>): Promise<User>;
+}
+```
+
+Return `User | null` for a lookup that may miss, and let the service turn it into a
+`NotFoundException`. A repository that throws HTTP exceptions has the transport layer's concerns in the
+data layer, and it is untestable without the framework.
+
+A row from an untyped driver is external input. A typed ORM (Prisma, Drizzle, Kysely) generates the row
+types from the schema — derive from those rather than hand-writing a parallel entity type.
+
+## Typed configuration
+
+```ts
+ConfigModule.forRoot({
+  validate: (raw) => EnvSchema.parse(raw),   // throws at boot on bad config
+  isGlobal: true,
+});
+```
+
+`ConfigService.get()` returns `T | undefined` by default, which spreads `!` through the codebase. Two
+fixes, both better than the `!`:
+
+```ts
+// Either: a typed accessor from the validated schema
+constructor(private readonly config: ConfigService<Env, true>) {}
+const port = this.config.get("PORT", { infer: true });   // number, not number | undefined
+
+// Or: skip ConfigService and import the validated object directly
+import { env } from "./config/env";
+```
+
+The second is simpler and fully typed. Use `ConfigService` when you need Nest's per-module config
+namespacing or test-time overriding; otherwise the plain module is less machinery.
+
+## Errors and exception filters
+
+Nest's built-in HTTP exceptions are the idiom — use them at the controller and service layer rather than a
+custom hierarchy that a filter then has to translate.
+
+```ts
+throw new NotFoundException(`user ${id} not found`);
+throw new ConflictException({ code: "EMAIL_TAKEN", message: "Email already registered" });
+```
+
+A catch-all filter for consistent response shape and for keeping internals out of the response body:
+
+```ts
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger(AllExceptionsFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const res = host.switchToHttp().getResponse<Response>();
+    const isHttp = exception instanceof HttpException;
+    const status = isHttp ? exception.getStatus() : 500;
+
+    this.logger.error("request failed", exception instanceof Error ? exception.stack : String(exception));
+
+    res.status(status).json({
+      error: {
+        code: isHttp ? exception.name : "INTERNAL_ERROR",
+        // A 500 message can carry a query string or a connection string. Never forward it.
+        message: isHttp ? exception.message : "Internal server error",
+      },
+    });
+  }
+}
+```
+
+The `exception: unknown` parameter is the correct type and forces the narrowing. The log gets the detail;
+the client gets a code.
+
+## Guards and request typing
+
+`Request` has no `user` property, so an auth guard that attaches one leaves every consumer casting.
+Declare it once via module augmentation instead of casting at each use:
+
+```ts
+// types/express.d.ts
+declare global {
+  namespace Express {
+    interface Request {
+      user?: AuthenticatedUser;
+    }
+  }
+}
+```
+
+```ts
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  canActivate(ctx: ExecutionContext): boolean {
+    const req = ctx.switchToHttp().getRequest<Request>();
+    const payload = this.verify(req.headers.authorization);   // returns AuthenticatedUser
+    req.user = payload;
+    return true;
+  }
+}
+```
+
+Keep `user` optional in the declaration — it is genuinely absent on unguarded routes, and pretending
+otherwise is the lie the type system was meant to catch. Read it through a typed decorator that asserts
+presence on guarded routes:
+
+```ts
+export const CurrentUser = createParamDecorator((_data, ctx: ExecutionContext): AuthenticatedUser => {
+  const { user } = ctx.switchToHttp().getRequest<Request>();
+  if (user === undefined) throw new UnauthorizedException();
+  return user;
+});
+```
+
+Verify a JWT's claims rather than trusting the decoded payload's shape. A decoded token is attacker-
+controlled data until the signature and the claims are both checked.
+
+## Response shaping
+
+The entity you load is not the object you return. Map explicitly:
+
+```ts
+type UserResponse = Pick<User, "id" | "email" | "name">;
+
+const toResponse = ({ id, email, name }: User): UserResponse => ({ id, email, name });
+```
+
+Annotating a handler's return type as `UserResponse` does not redact anything — the type erases and
+`res.json(entity)` still serializes `passwordHash`. `class-transformer`'s `@Exclude()` plus
+`ClassSerializerInterceptor` is the framework answer, but it only works on class instances, so it silently
+does nothing for a plain object from Prisma. The explicit mapping function always works, so prefer it at
+any boundary carrying secrets.

--- a/home/dot_agents/skills/typescript/references/patterns.md
+++ b/home/dot_agents/skills/typescript/references/patterns.md
@@ -1,0 +1,348 @@
+# Application patterns reference
+
+Companion to `SKILL.md`. Read the section you need.
+
+- [Result and typed errors](#result-and-typed-errors)
+- [Branded types](#branded-types)
+- [Schema validation with Zod](#schema-validation-with-zod)
+- [Typed configuration](#typed-configuration)
+- [Trust boundaries and response shapes](#trust-boundaries-and-response-shapes)
+- [Project layout](#project-layout)
+- [Path aliases](#path-aliases)
+- [Barrel files: the cost](#barrel-files-the-cost)
+- [Migrating JavaScript to TypeScript](#migrating-javascript-to-typescript)
+- [Migrating CommonJS to ESM](#migrating-commonjs-to-esm)
+
+## Result and typed errors
+
+```ts
+export type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+export const ok = <T,>(value: T): Result<T, never> => ({ ok: true, value });
+export const err = <E,>(error: E): Result<never, E> => ({ ok: false, error });
+```
+
+Use it for failures the caller is expected to handle. The type makes the unhappy path impossible to
+forget, which is what you want for a case that happens every day.
+
+```ts
+async function findUser(id: UserId): Promise<Result<User, "not_found" | "db_unavailable">> {
+  ...
+}
+
+const result = await findUser(id);
+if (!result.ok) {
+  return respond(result.error === "not_found" ? 404 : 503);
+}
+result.value.email;   // narrowed
+```
+
+A literal union for `E` beats a string: the caller can `switch` on it exhaustively, and a new failure mode
+breaks the build at every handler instead of falling through a generic 500.
+
+Throw for broken invariants and misconfiguration. Threading a `Result` through twelve frames where no
+frame can recover adds noise and hides the one place that actually handles it.
+
+Typed error classes, when you do throw:
+
+```ts
+export class AppError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status: number,
+    readonly cause?: unknown,
+  ) {
+    super(message, { cause });
+    this.name = new.target.name;    // survives subclassing, unlike a literal
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(resource: string, id: string) {
+    super(`${resource} ${id} not found`, "NOT_FOUND", 404);
+  }
+}
+```
+
+Two details that bite: set `name` from `new.target.name` so subclasses report themselves correctly, and
+pass `{ cause }` so the original stack survives — a re-thrown error without `cause` costs you the actual
+failure site.
+
+`instanceof` on a custom Error is unreliable across realms (worker boundaries, bundled duplicates of the
+same class, `target: ES5` output). Discriminate on `code` when the error crosses a boundary.
+
+In `catch`, the variable is `unknown`. Narrow it:
+
+```ts
+try { ... } catch (e) {
+  const message = e instanceof Error ? e.message : String(e);
+}
+```
+
+## Branded types
+
+Two `string` parameters that mean different things are a swap waiting to happen, and the compiler cannot
+see it.
+
+```ts
+type UserId = string & { readonly __brand: "UserId" };
+type OrderId = string & { readonly __brand: "OrderId" };
+
+export function toUserId(raw: string): UserId {
+  if (!UUID_RE.test(raw)) throw new AppError(`bad user id: ${raw}`, "BAD_ID", 400);
+  return raw as UserId;    // the one earned cast: validation just ran
+}
+
+function cancelOrder(order: OrderId, actor: UserId) { ... }
+cancelOrder(userId, orderId);   // now a compile error
+```
+
+Match the `readonly __brand: "X"` shape rather than inventing a convention, so brands from different
+modules read the same. Past a handful of brands, factor the shape into one helper so it cannot drift:
+
+```ts
+type Brand<T, B extends string> = T & { readonly __brand: B };
+type UserId = Brand<string, "UserId">;
+type OrderId = Brand<string, "OrderId">;
+```
+
+Brand deliberately, not reflexively. Brand an identifier that could be confused with another identifier,
+or a value carrying a validated invariant (`Email`, `PositiveInt`, `SanitizedHtml`). Do not brand a
+`durationMs` that nothing else could be mistaken for — the ceremony buys no safety.
+
+The cast inside the constructor is the point: exactly one place holds the `as`, and it sits directly below
+the check that earns it. Everything downstream is honest.
+
+## Schema validation with Zod
+
+```ts
+import { z } from "zod";
+
+export const UserSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  role: z.enum(["viewer", "editor", "admin"]),
+  createdAt: z.coerce.date(),
+});
+
+export type User = z.infer<typeof UserSchema>;   // derived, cannot drift
+```
+
+The schema is the source of truth for both the runtime check and the type. Writing an `interface User`
+next to this schema creates two truths that both compile while disagreeing.
+
+`parse` vs `safeParse`:
+
+```ts
+// parse: a bad value means the program is broken. Fail loudly, at boot.
+export const env = EnvSchema.parse(process.env);
+
+// safeParse: a bad value is an expected outcome you must report to a user.
+const parsed = CreateUserSchema.safeParse(req.body);
+if (!parsed.success) {
+  return res.status(422).json({
+    error: { code: "VALIDATION_ERROR", message: "Invalid user", details: parsed.error.flatten() },
+  });
+}
+const user = await service.create(parsed.data);   // typed and trusted from here
+```
+
+Where schemas belong: HTTP handlers, message-queue consumers, webhook receivers, third-party API
+responses, config and environment loading, `localStorage` and persisted JSON, and anything from
+`postMessage` or IPC.
+
+Where they do not: between two internal functions that share a type. Re-validating there says the types
+in between are not trusted, which means they are decoration.
+
+Derive related shapes from the base schema rather than declaring siblings:
+
+```ts
+export const CreateUserSchema = UserSchema.omit({ id: true, createdAt: true });
+export const UpdateUserSchema = CreateUserSchema.partial();
+```
+
+Sanitization is a transform, so the type says it happened:
+
+```ts
+const SafeHtml = z.string().transform((s) => DOMPurify.sanitize(s));
+```
+
+Persisted JSON deserves a version field and a `try`/`catch` around the parse — the stored blob was written
+by an older version of your code, which is a different trust problem from a network payload.
+
+## Typed configuration
+
+```ts
+const EnvSchema = z.object({
+  NODE_ENV: z.enum(["development", "test", "production"]),
+  PORT: z.coerce.number().int().positive().default(3000),
+  DATABASE_URL: z.string().url(),
+  JWT_SECRET: z.string().min(32),
+  REDIS_URL: z.string().url().optional(),
+});
+
+export const env = EnvSchema.parse(process.env);
+export type Env = z.infer<typeof EnvSchema>;
+```
+
+`process.env` values are all `string | undefined`, so `z.coerce.number()` is doing real work — without it
+`PORT` is the string `"3000"` and `port + 1` is `"30001"`.
+
+Failing at startup rather than at first use is the whole point. A missing `JWT_SECRET` should stop the
+deploy, not produce a 500 for the first user who logs in.
+
+Never log the parsed config wholesale — it now holds secrets in a conveniently typed object.
+
+## Trust boundaries and response shapes
+
+```ts
+interface User {
+  id: UserId;
+  email: string;
+  passwordHash: string;
+  resetToken: string | null;
+}
+
+// Allowlist. Adding a sensitive field to `User` cannot leak it.
+type PublicUser = Pick<User, "id" | "email">;
+
+// Denylist. Adding `ssn` to `User` leaks it silently.
+type PublicUser = Omit<User, "passwordHash" | "resetToken">;
+```
+
+Prefer `Pick` on anything crossing a trust boundary: an allowlist fails closed, a denylist fails open.
+The failure mode is a data leak introduced by an unrelated commit that nobody reviewed as a security
+change.
+
+Types alone do not redact. A `PublicUser`-typed variable that came from `res.json(user)` still serializes
+every field, because the type erased at compile time. Write the mapping function and return its result.
+
+```ts
+const toPublicUser = ({ id, email }: User): PublicUser => ({ id, email });
+```
+
+## Project layout
+
+Group by feature, not by technical kind. `features/users/` keeps everything one change touches together;
+`services/`, `types/`, `controllers/` spreads a single feature across four directories, so every change is
+a four-file diff and every directory is a merge-conflict hotspot.
+
+```
+src/
+├── features/
+│   └── users/
+│       ├── index.ts             # the module's public surface
+│       ├── user.schema.ts       # Zod schemas + inferred types
+│       ├── user.service.ts      # business logic
+│       ├── user.repository.ts   # data access (internal, not exported)
+│       └── user.controller.ts   # HTTP boundary — parses input
+├── shared/
+│   ├── result.ts
+│   └── errors.ts
+├── infrastructure/              # db, cache, logging clients
+└── config/
+    └── env.ts
+```
+
+The rule that gives this structure its value: **a feature's `index.ts` is its contract.** Export the
+service and the types; do not export the repository. If another feature imports
+`users/user.repository.ts` directly, the boundary is gone and the two features are one.
+
+## Barrel files: the cost
+
+A feature's `index.ts` re-exporting its public surface is worth it — that is the module boundary. A
+project-wide `src/index.ts` that re-exports everything is not, and the costs are easy to miss:
+
+- **Circular imports.** Two features that both import from the root barrel now depend on each other
+  through it. The failure is a runtime `undefined` at module-init time, far from the cause.
+- **Everything loads.** Importing one helper through a barrel pulls in every module the barrel names, and
+  their side effects with them. In a test suite that is measurable startup cost per file.
+- **Tree-shaking gets harder.** A bundler can often see through it, but any module with side effects in
+  the chain defeats that, and `sideEffects: false` in `package.json` is a claim you may not be able to
+  honour.
+
+Rule of thumb: one barrel per feature, exporting that feature's contract. No barrel above that. Deep
+imports within your own feature are fine — the boundary exists for other features, not for you.
+
+## Path aliases
+
+```json
+{
+  "compilerOptions": {
+    "paths": { "@/*": ["./src/*"] }
+  }
+}
+```
+
+No `baseUrl`. `paths` resolves relative to the tsconfig on its own since TypeScript 4.4, and TypeScript 7
+removed `baseUrl` outright — a config that still sets it fails to load after the upgrade.
+
+`tsc` resolves aliases for type checking only. The runtime — Node, Vite, Vitest, Jest — needs its own
+mapping, or the build type-checks and then fails to start. Configure both, and keep them in sync:
+
+- Vite and Vitest: `resolve.alias`, or the `vite-tsconfig-paths` plugin so one file owns the mapping
+- Jest: `moduleNameMapper`
+- Plain Node: subpath imports in `package.json` (`"imports": { "#*": "./src/*" }`) work at runtime with no
+  extra tooling, which makes them the lower-risk choice for a Node service
+
+One alias is usually enough. Four (`@features/*`, `@shared/*`, `@config/*`, `@/*`) mostly generate
+bikeshedding about which to use.
+
+## Migrating JavaScript to TypeScript
+
+Incremental, one reviewable commit at a time.
+
+1. Add TypeScript and a `tsconfig.json` with `allowJs: true`, `checkJs: false`, `strict: true`. Existing
+   `.js` files keep working; new `.ts` files are strict from birth.
+2. Add `typecheck` to CI immediately, even when it passes trivially. A check added later never catches the
+   regressions from the migration itself.
+3. Convert **leaf modules first** — a file with no local imports has no type surface to negotiate. Utility
+   and constants files are the cheapest wins and unblock everything above them.
+4. Per file: rename, fix the errors the compiler reports, run the tests. Do not refactor in the same
+   commit. A rename plus a refactor is a diff nobody can review.
+5. `any` at the seams is acceptable and temporary. `any` in the domain model is the thing you were trying
+   to escape. Track the seams with a `// TODO(ts-migration)` marker you can grep.
+6. Turn on one strict flag at a time, each in its own commit. `noUncheckedIndexedAccess` in particular
+   will produce hundreds of errors in a mature codebase.
+
+JSDoc buys type checking in a file you are not ready to rename — useful for a large module you want
+covered before touching:
+
+```js
+/**
+ * @param {string} name
+ * @param {number} age
+ * @returns {import("./types").User}
+ */
+function createUser(name, age) { ... }
+```
+
+Flip `checkJs: true` per file with `// @ts-check` at the top, so the noise arrives on your schedule.
+
+## Migrating CommonJS to ESM
+
+```json
+{
+  "type": "module",
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } }
+}
+```
+
+The parts that actually break:
+
+- **Relative imports need file extensions** under Node ESM: `./user.js`, not `./user`. In TypeScript
+  source you still write `.js`, because that is what the emitted file resolves to.
+- **`__dirname` and `__filename` do not exist.** Use `import.meta.dirname` (Node 20.11+) or
+  `fileURLToPath(import.meta.url)`.
+- **`require` of an ESM-only package fails.** Node 22.12+ can `require()` a synchronous ESM graph, but
+  do not rely on it in a library that supports older runtimes.
+- **JSON imports need an attribute**: `import pkg from "./package.json" with { type: "json" }`.
+- **`verbatimModuleSyntax`** makes import elision explicit, so a type-only import must say `import type`.
+  Turn it on during the migration, not after — it surfaces the ambiguous imports while you are already
+  looking at them.
+
+Test runners are the usual sticking point. Vitest handles ESM natively; Jest needs
+`--experimental-vm-modules` or a transform. Decide before converting, not after CI turns red.

--- a/home/dot_agents/skills/typescript/references/react.md
+++ b/home/dot_agents/skills/typescript/references/react.md
@@ -1,0 +1,270 @@
+# React and TypeScript
+
+Companion to `SKILL.md`. Check the project's `@types/react` major version before applying anything here —
+React 19 changed several typings in ways that break React 18 patterns and vice versa.
+
+- [Component props](#component-props)
+- [Generic and polymorphic components](#generic-and-polymorphic-components)
+- [Hooks](#hooks)
+- [Events and forms](#events-and-forms)
+- [Context](#context)
+- [Reducers and state machines](#reducers-and-state-machines)
+- [Async data and Server Components](#async-data-and-server-components)
+- [React 19 typing changes](#react-19-typing-changes)
+
+## Component props
+
+Declare the props type and annotate the parameter. Skip `React.FC`.
+
+```tsx
+interface ButtonProps {
+  label: string;
+  onClick: () => void;
+  variant?: "primary" | "secondary";
+}
+
+export function Button({ label, onClick, variant = "primary" }: ButtonProps) {
+  return <button className={variant} onClick={onClick}>{label}</button>;
+}
+```
+
+`React.FC` adds nothing and costs something: it fixes the return type, blocks a generic component, and in
+React 18 typings silently added `children` you had not declared. The plain function declaration is what
+the ecosystem converged on.
+
+Declare `children` when you accept it:
+
+```tsx
+interface CardProps {
+  title: string;
+  children: React.ReactNode;
+}
+```
+
+`React.ReactNode` for anything renderable (the usual choice). `React.ReactElement` only when you need a
+single element to clone or inspect.
+
+Extend the underlying element's props instead of re-declaring them, so a wrapper accepts everything the
+native element does:
+
+```tsx
+interface InputProps extends React.ComponentProps<"input"> {
+  label: string;
+  error?: string;
+}
+
+export function Input({ label, error, ...rest }: InputProps) {
+  return (
+    <label>
+      {label}
+      <input aria-invalid={error !== undefined} {...rest} />
+      {error !== undefined && <span role="alert">{error}</span>}
+    </label>
+  );
+}
+```
+
+`React.ComponentProps<"input">` includes `ref` in React 19 typings. `ComponentPropsWithoutRef<"input">` is
+the React 18 spelling when you are not forwarding.
+
+Model variants as a discriminated union so contradictory props cannot be passed:
+
+```tsx
+type AlertProps =
+  | { kind: "info"; message: string }
+  | { kind: "error"; message: string; onRetry: () => void };
+```
+
+That is stronger than `{ kind: string; onRetry?: () => void }`, which lets a caller build an error alert
+with no retry handler and no compiler complaint.
+
+## Generic and polymorphic components
+
+A generic component keeps the relationship between the data and the callbacks:
+
+```tsx
+interface ListProps<T> {
+  items: readonly T[];
+  renderItem: (item: T) => React.ReactNode;
+  keyOf: (item: T) => string;
+}
+
+export function List<T,>({ items, renderItem, keyOf }: ListProps<T>) {
+  return <ul>{items.map((i) => <li key={keyOf(i)}>{renderItem(i)}</li>)}</ul>;
+}
+```
+
+The trailing comma in `<T,>` is needed in `.tsx` files, where `<T>` parses as JSX.
+
+Polymorphic components (`as` prop) are genuinely hard to type well and produce error messages users
+cannot read. Before reaching for one, check whether two named components would do. If you need it:
+
+```tsx
+type PolymorphicProps<E extends React.ElementType> = {
+  as?: E;
+} & Omit<React.ComponentProps<E>, "as">;
+
+export function Box<E extends React.ElementType = "div">({ as, ...rest }: PolymorphicProps<E>) {
+  const Component = as ?? "div";
+  return <Component {...rest} />;
+}
+```
+
+## Hooks
+
+```tsx
+const [count, setCount] = useState(0);                    // inferred number — leave it
+const [user, setUser] = useState<User | null>(null);      // annotate: inference gives null
+const [items, setItems] = useState<Item[]>([]);           // annotate: inference gives never[]
+```
+
+Annotate `useState` when the initial value is narrower than the states the value will hold. That is the
+whole rule.
+
+Refs, and the React 19 change that trips people up:
+
+```tsx
+const inputRef = useRef<HTMLInputElement>(null);   // DOM ref: RefObject, .current may be null
+const timer = useRef<number | undefined>(undefined); // mutable value: pass the initial value explicitly
+```
+
+`@types/react` 19 requires an argument to `useRef`. `useRef<number>()` with no argument is now an error,
+which is a good change — it forces you to say whether the initial state is `undefined`.
+
+Custom hooks: annotate the return type, or return a tuple `as const`.
+
+```tsx
+function useToggle(initial = false) {
+  const [on, setOn] = useState(initial);
+  const toggle = useCallback(() => setOn((v) => !v), []);
+  return [on, toggle] as const;   // [boolean, () => void], not (boolean | (() => void))[]
+}
+```
+
+Without `as const` the tuple widens to an array union and destructuring loses both types.
+
+## Events and forms
+
+```tsx
+function Form() {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const parsed = LoginSchema.safeParse(Object.fromEntries(data));
+    if (!parsed.success) { ...; return; }
+    void submit(parsed.data);
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) { ... }
+}
+```
+
+`FormData` entries are `string | File`, so form input is external input. Parse it — this is the same
+boundary rule as an HTTP body, and it is the one people skip because the data "came from our own form".
+
+Prefer `e.currentTarget` over `e.target`. `currentTarget` is typed as the element the handler is attached
+to; `target` is whatever was clicked, and its type is a guess.
+
+Common handler types: `React.MouseEvent<HTMLButtonElement>`, `React.KeyboardEvent<HTMLInputElement>`,
+`React.ChangeEvent<HTMLSelectElement>`, `React.FocusEvent<HTMLInputElement>`.
+
+Never pass an `async` function where React expects `() => void` without a `void` marker — an async
+`onClick` that rejects fails silently:
+
+```tsx
+<button onClick={() => void save()}>Save</button>
+```
+
+## Context
+
+Type the context by its value, and make the missing-provider case impossible to ignore:
+
+```tsx
+interface AuthContextValue {
+  user: User | null;
+  signOut: () => void;
+}
+
+const AuthContext = React.createContext<AuthContextValue | undefined>(undefined);
+
+export function useAuth(): AuthContextValue {
+  const ctx = React.useContext(AuthContext);
+  if (ctx === undefined) throw new Error("useAuth must be used inside <AuthProvider>");
+  return ctx;
+}
+```
+
+The `undefined` default plus the throwing hook is the pattern worth copying. A fake default object
+(`{ user: null, signOut: () => {} }`) type-checks everywhere and turns a missing provider into a silent
+no-op that surfaces as a bug report weeks later.
+
+Export the hook, not the context, so consumers cannot bypass the check.
+
+## Reducers and state machines
+
+`useReducer` with two discriminated unions is where TypeScript pays off most in React:
+
+```tsx
+type State =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; items: Item[] }
+  | { kind: "error"; message: string };
+
+type Action =
+  | { type: "fetch" }
+  | { type: "resolved"; items: Item[] }
+  | { type: "rejected"; message: string };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "fetch":    return { kind: "loading" };
+    case "resolved": return { kind: "ready", items: action.items };
+    case "rejected": return { kind: "error", message: action.message };
+    default: {
+      const _exhaustive: never = action;
+      return _exhaustive;
+    }
+  }
+}
+```
+
+The payoff in the component: `state.items` exists only in the `ready` branch, so the render cannot read a
+field that is not there. That deletes the whole class of `loading && data && !error` bugs.
+
+## Async data and Server Components
+
+An `async` component is a Server Component. Its return type is `Promise<React.ReactNode>`, and calling a
+hook inside it is an error the types will not always catch — the boundary is a framework rule, not a type
+rule.
+
+```tsx
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const user = await getUser(toUserId(id));
+  return <Profile user={user} />;
+}
+```
+
+In recent Next.js, `params` and `searchParams` are promises. A route param is a string from a URL — an
+untrusted value. Parse or brand it before it reaches a query.
+
+The props of a Client Component receiving data from a Server Component must be serializable. A type can
+describe a `Date` or a function crossing that boundary; the runtime cannot carry it. Types do not enforce
+serializability, so check it deliberately.
+
+## React 19 typing changes
+
+Worth knowing because they turn working React 18 code into compile errors and vice versa:
+
+| Change | Effect |
+|---|---|
+| `ref` is a normal prop on function components | `forwardRef` is no longer needed; a `ComponentProps<"input">` spread now includes `ref` |
+| `useRef` requires an argument | `useRef<T>()` is an error — pass `null` or `undefined` explicitly |
+| `JSX` global namespace removed | Use `React.JSX.Element` instead of the bare global `JSX.Element` |
+| `React.FC` no longer implies `children` | Declare `children` in the props type |
+| `useActionState` replaces `useFormState` | Returns `[state, action, isPending]` |
+| `use(promise)` and `use(context)` | Reads a promise or context; only legal inside a component or hook |
+
+When a third-party library's types lag a React major, `@ts-expect-error` with the reason and the removal
+condition is the honest suppression. `any` on the component is not.

--- a/home/dot_agents/skills/typescript/references/toolchain.md
+++ b/home/dot_agents/skills/typescript/references/toolchain.md
@@ -6,8 +6,8 @@ Companion to `SKILL.md`. Read the section you need.
 - [Options TypeScript 7 removed](#options-typescript-7-removed)
 - [Which config for which target](#which-config-for-which-target)
 - [Project references](#project-references)
-- [Biome](#biome)
-- [Rules that catch real bugs](#rules-that-catch-real-bugs)
+- [Ultracite](#ultracite)
+- [The rules Ultracite leaves out](#the-rules-ultracite-leaves-out)
 - [Vitest](#vitest)
 - [Testing types](#testing-types)
 - [Vite](#vite)
@@ -17,8 +17,9 @@ Companion to `SKILL.md`. Read the section you need.
 - [Scripts and CI](#scripts-and-ci)
 - [Publishing a library](#publishing-a-library)
 
-Start from `assets/tsconfig.strict.json` and `assets/biome.jsonc` on a new project. On an existing
-project, read what is there first and change nothing that was not the task.
+Start from `assets/tsconfig.strict.json` and `assets/biome.jsonc` on a new project, or run
+`ultracite init` and let it write the lint config. On an existing project, read what is there first and
+change nothing that was not the task.
 
 ## tsconfig flags, explained
 
@@ -140,75 +141,115 @@ The parts that trip people up:
 - **References are not module resolution.** They tell `tsc` about build order; the runtime still needs
   workspace linking (pnpm workspaces) or a `paths` entry.
 
-## Biome
+## Ultracite
 
-Biome is one Rust binary that lints and formats. Choosing it means there is no ESLint, no Prettier, and
-no `eslint-config-prettier` reconciling the two — the reason people reach for it is that the whole
-category of config-fighting-config disappears, and it runs fast enough to be a pre-commit hook.
+Ultracite is the linting entry point. It is a preset over Biome, and Biome is one Rust binary that lints
+and formats. The stack has no ESLint, no Prettier, and no `eslint-config-prettier` reconciling the two.
+Ultracite adds the part a bare Biome config makes you write by hand: about 365 rules already set to
+error, the formatter, the ignore globs, the import sorting, and a framework preset per framework.
 
 ```bash
-pnpm add -D --save-exact @biomejs/biome
-pnpm biome check --write .     # format + lint + organize imports, in one pass
+pnpm add -D --save-exact ultracite @biomejs/biome
+pnpm ultracite init          # writes biome.jsonc, and detects your frameworks
 ```
 
-Start from `assets/biome.jsonc`. Three things about it are worth knowing before you write your own.
+| Command | Does |
+|---|---|
+| `ultracite check` | Lints and checks formatting. Writes nothing. This is the CI gate. |
+| `ultracite fix` | Applies safe fixes. `--unsafe` allows fixes that can change behaviour. |
+| `ultracite doctor` | Reports a broken setup — a missing binary, a config that does not extend the preset, a leftover Prettier config. |
+| `ultracite init` | Sets the project up. `--type-aware` adds the project-graph preset, and `--linter biome` picks the provider. |
 
-**Use the `.jsonc` extension.** Biome reads comments in `biome.jsonc`. A comment in `biome.json` makes
-Biome fall back to its defaults **without reporting an error** — severities revert, nursery rules switch
-off, and the formatter goes back to tabs. Nothing tells you. A config that silently does not apply is
-worse than one that fails, so pick the extension that cannot do that.
+Start from `assets/biome.jsonc`. It extends two presets, and it adds only what the presets leave out.
 
-**Biome does not replace `tsc`.** It has its own type inference, not a type checker. `tsc --noEmit`
-remains the thing that proves your types. Biome's job is the class of bug `tsc` does not model — a
+```jsonc
+{ "extends": ["ultracite/biome/core", "ultracite/biome/type-aware"] }
+```
+
+**Install Ultracite as a dev dependency.** Biome resolves `extends` from the project `node_modules`, so
+an `npx ultracite` call alone leaves a config that cannot load its own preset. Ultracite detects this one
+and says so, which is the rare failure that explains itself.
+
+**Call the CLI through a package script.** `ultracite check` spawns `biome` from `PATH`. A package script
+puts `node_modules/.bin` on `PATH` and a bare shell call does not, so the direct call dies with `ENOENT`
+on a project that has no global Biome.
+
+**Ultracite does not replace `tsc`.** Biome has its own inference, not a type checker. `tsc --noEmit`
+remains the thing that proves your types. The linter's job is the class of bug `tsc` does not model — a
 floating promise above all.
 
-**Ignore patterns come from `.gitignore`** when `vcs.useIgnoreFile` is on, so there is one list instead of
-two. The catch: with that setting and no ignore file, Biome exits with a configuration error rather than a
-warning, which surprises people on a fresh repo.
+**Use the `.jsonc` extension.** Biome reads comments in `biome.jsonc`. A comment in `biome.json` makes
+Biome fall back to its defaults **without reporting an error** — severities revert and the formatter goes
+back to tabs. Nothing tells you. A config that silently does not apply is worse than one that fails.
 
-Biome 2 renamed a few things that older examples still use. `include`/`ignore` became one `includes` list
-where a `!` prefix excludes, and top-level `organizeImports` became an assist action at
-`assist.actions.source.organizeImports`.
+**Commit a `.gitignore` before the first run.** `core` sets `vcs.useIgnoreFile`, which is what keeps the
+ignore list in one file instead of two. With that on and no ignore file present, Biome exits with a
+configuration error rather than a warning, and nothing lints at all. It surprises people on a fresh repo,
+and adopting the preset is what turns it on.
 
-Coming from ESLint and Prettier, let Biome do the translation instead of hand-porting:
+### The presets
 
-```bash
-biome migrate eslint --write
-biome migrate prettier --write
+`core` is the base. It already sets every rule this skill argues for: `noExplicitAny`, `noTsIgnore`,
+`noUnnecessaryConditions`, `noNonNullAssertion`, `noEnum`, `useImportType`, and `noUnusedVariables`. Do
+not restate them — a hand-written list of 30 rules on top of `core` is 30 lines that change nothing.
+
+`type-aware` adds the rules that need the project graph: `noImportCycles`, `noUndeclaredDependencies`,
+`noUnresolvedImports`, `noPrivateImports`, `noDeprecatedImports`, and `useArraySortCompare`.
+
+Then one preset per framework the project actually has — `react`, `nestjs`, `vitest`, `next`, `vue`,
+`svelte`, `solid`, `angular`, `astro`, `qwik`, `remix`, `tanstack`, `jest`.
+
+**Read the `nestjs` preset before adding it.** It turns `noEnum`, `noUselessConstructor`,
+`noStaticOnlyClass`, and `noParameterProperties` **off**, because a decorator-driven framework needs all
+four. That is the right call for NestJS, and it also means a NestJS project silently loses the "no `enum`"
+rule this skill recommends elsewhere. Know which rules your presets switch off.
+
+To change one rule, override it by name — do not fork the preset:
+
+```jsonc
+{
+  "extends": ["ultracite/biome/core"],
+  "linter": { "rules": { "a11y": { "useButtonType": "off" } } }
+}
 ```
 
-It maps the rules it has equivalents for and leaves the rest, so read the result — the diff is the honest
-report of what Biome does not cover.
+## The rules Ultracite leaves out
 
-## Rules that catch real bugs
+Three rules are the highest-value thing a linter adds on top of `tsc`, and **no Ultracite preset enables
+any of them** — not even `type-aware`. Ultracite avoids `nursery` rules on purpose
+([ultracite#457](https://github.com/haydenbleasel/ultracite/issues/457)). Name them yourself:
 
-Biome's recommended set is decent. These are the additions worth making explicit, with the group each
-belongs to (the group is part of the config path, so getting it wrong means the rule silently does not
-apply):
+```jsonc
+"linter": {
+  "rules": {
+    "nursery": {
+      "noFloatingPromises": "error",
+      "noMisusedPromises": "error",
+      "useExhaustiveSwitchCases": "error"
+    }
+  }
+}
+```
 
-| Rule | Group | Why |
-|---|---|---|
-| `noFloatingPromises` | `nursery` | An unawaited promise swallows its rejection, so the failure vanishes. The highest-value rule here. |
-| `noMisusedPromises` | `nursery` | An `async` callback passed where `() => void` is expected — an event handler, a `forEach`. The rejection goes nowhere. |
-| `useExhaustiveSwitchCases` | `nursery` | The linter's version of the `never` default arm. |
-| `noUnnecessaryConditions` | `suspicious` | A check the types prove is always true. Either the check is dead or the type is wrong. |
-| `noExplicitAny` | `suspicious` | Defaults to a warning. Make it an error on a new project. |
-| `noTsIgnore` | `suspicious` | Pushes you to `@ts-expect-error`, which expires when the error does. |
-| `noNonNullAssertion` | `style` | Defaults to a warning. |
-| `noEnum` | `style` | An `enum` emits runtime code, is nominally typed, and blocks type-stripping runtimes. |
-| `useImportType` | `style` | Keeps type-only imports out of the runtime graph. Pairs with `verbatimModuleSyntax`. |
+| Rule | Why |
+|---|---|
+| `noFloatingPromises` | An unawaited promise swallows its rejection, so the failure vanishes. The highest-value rule here. |
+| `noMisusedPromises` | An `async` callback passed where `() => void` is expected — an event handler, a `forEach`. The rejection goes nowhere. |
+| `useExhaustiveSwitchCases` | The linter's version of the `never` default arm. Keep the `never` binding in the code too, because it survives a config change. |
+
+This is the gap worth checking on any Ultracite project: the config looks comprehensive at 365 rules, and
+the three that catch unhandled rejections are still off.
 
 ### The type-aware rules, and their real limits
 
-The first four need type information, and Biome's inference is its own — not `tsc`'s. Two consequences
-that decide how much you can lean on it:
+These three need type information, and Biome's inference is its own — not `tsc`'s. Two consequences that
+decide how much you can lean on it:
 
-- **They are still `nursery` as of Biome 2.5**, so they are opt-in by name and their behaviour can change
-  between minor versions. Install with `--save-exact` and pin the version, or a patch bump silently
-  changes what CI rejects.
+- **They are `nursery` as of Biome 2.5**, so their behaviour can change between minor versions. Install
+  with `--save-exact` and pin the version, or a patch bump silently changes what CI rejects.
 - **A `types` domain does not enable them.** Setting `"domains": { "types": "all" }` looks like it should
-  and does not — the nursery rules stay off. Name each rule under `nursery`. This is the mistake worth
-  checking for, because the config looks stricter than it is.
+  and does not. Neither does `ultracite/biome/type-aware`, whose name suggests it would. Name each rule
+  under `nursery`.
 
 What the inference does and does not reach, measured on Biome 2.5:
 
@@ -227,8 +268,18 @@ exactly where an unhandled rejection hurts most — are still on you and the rev
 those call sites deliberately rather than assuming the linter is watching.
 
 If your project's tolerance for unhandled rejections is zero and it is full of framework callbacks,
-typescript-eslint's `no-misused-promises` still covers more. That is the tradeoff Biome asks you to
+typescript-eslint's `no-misused-promises` still covers more. That is the tradeoff this stack asks you to
 accept in exchange for one fast binary and no config reconciliation.
+
+### Migrating an existing project
+
+`ultracite init` does the migration. It detects an existing ESLint, Prettier, or bare Biome setup, offers
+to remove the configs it replaces, and rewrites `biome.jsonc` to extend the preset. It also detects your
+frameworks from `package.json` and adds the matching presets.
+
+Read the resulting diff rather than trusting it. A hand-tuned ESLint rule with no Biome equivalent is
+dropped silently, and that diff is the honest report of what moving to this stack costs you.
+
 ## Vitest
 
 ```ts
@@ -331,18 +382,20 @@ instead of quietly resolving something else.
 Biome formats, so there is no Prettier. That is most of the appeal: one binary, one config file, and no
 `eslint-config-prettier` layer whose job is to stop two tools from undoing each other's work.
 
-One default worth overriding deliberately: **Biome indents with tabs.** Set `formatter.indentStyle`
-explicitly either way. Left implicit, the first person whose editor disagrees produces a whole-file diff
-and buries the real change.
+`ultracite/biome/core` already decides the format: spaces, width 2, line width 80, LF endings, semicolons
+always, double-quoted JSX. A bare Biome config defaults to **tabs**, so a project that adopts Ultracite
+gets this settled instead of arguing about it. Take the preset's answer. The values do not matter, and
+having one committed file that decides them does.
+
+Override a format setting only for a reason you can say out loud:
 
 ```jsonc
-"formatter": { "indentStyle": "space", "indentWidth": 2, "lineWidth": 100 }
+"formatter": { "lineWidth": 100 }
 ```
 
-The values do not matter. Having one committed file that decides them does.
-
-`biome check --write` formats, lints with safe fixes, and sorts imports in one pass, which is what makes
-it viable as a pre-commit hook rather than a CI-only step.
+`ultracite fix` formats, lints with safe fixes, and sorts imports in one pass, which is what makes it
+viable as a pre-commit hook rather than a CI-only step. Ultracite writes the hook for you during `init`,
+and it runs `ultracite fix` through `lint-staged`.
 
 ## When the type check gets slow
 
@@ -379,8 +432,8 @@ directly, with no compiler-API dependency.
 {
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "biome check .",
-    "fix": "biome check --write .",
+    "lint": "ultracite check",
+    "fix": "ultracite fix",
     "test": "vitest run",
     "build": "tsc --noEmit && vite build",
     "check": "pnpm typecheck && pnpm lint && pnpm test"
@@ -388,13 +441,14 @@ directly, with no compiler-API dependency.
 }
 ```
 
-In CI, `biome ci .` instead of `biome check .` — same checks, but it never writes and its output is shaped
-for a CI log.
+Route every call through a script like this. `ultracite check` spawns `biome` from `PATH`, and a package
+script is what puts `node_modules/.bin` there. In a monorepo, define `check` and `fix` at the root and
+register them in `turbo.json` as `//#check` and `//#fix`, with `cache: false` on the fix task.
 
-All three gates check different things, and none subsumes another: `tsc` proves shapes, Biome proves
-formatting plus the type-aware invariants `tsc` does not model (floating promises above all), tests prove
-behaviour. Run all three before claiming a change works. Biome being fast is not a reason to skip `tsc` —
-they do not overlap.
+All three gates check different things, and none subsumes another: `tsc` proves shapes, Ultracite proves
+formatting plus the invariants `tsc` does not model (floating promises above all), tests prove behaviour.
+Run all three before claiming a change works. Ultracite being fast is not a reason to skip `tsc` — they do
+not overlap.
 
 Run them in that order locally — `tsc` is the fastest to fail and gives the clearest message.
 

--- a/home/dot_agents/skills/typescript/references/toolchain.md
+++ b/home/dot_agents/skills/typescript/references/toolchain.md
@@ -1,0 +1,425 @@
+# Toolchain reference
+
+Companion to `SKILL.md`. Read the section you need.
+
+- [tsconfig flags, explained](#tsconfig-flags-explained)
+- [Options TypeScript 7 removed](#options-typescript-7-removed)
+- [Which config for which target](#which-config-for-which-target)
+- [Project references](#project-references)
+- [Biome](#biome)
+- [Rules that catch real bugs](#rules-that-catch-real-bugs)
+- [Vitest](#vitest)
+- [Testing types](#testing-types)
+- [Vite](#vite)
+- [pnpm](#pnpm)
+- [Formatting](#formatting)
+- [When the type check gets slow](#when-the-type-check-gets-slow)
+- [Scripts and CI](#scripts-and-ci)
+- [Publishing a library](#publishing-a-library)
+
+Start from `assets/tsconfig.strict.json` and `assets/biome.jsonc` on a new project. On an existing
+project, read what is there first and change nothing that was not the task.
+
+## tsconfig flags, explained
+
+`strict: true` turns on the group that matters most: `noImplicitAny`, `strictNullChecks`,
+`strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`,
+`strictBuiltinIteratorReturn`, `noImplicitThis`, `useUnknownInCatchVariables`, `alwaysStrict`. Never list
+these individually — the group grows between releases (`strictBuiltinIteratorReturn` joined in 5.6) and an
+explicit list silently misses the new member.
+
+`tsc --init` is a good starting point rather than a stub. It writes `strict`,
+`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `verbatimModuleSyntax`, `isolatedModules`,
+`noUncheckedSideEffectImports`, `moduleDetection: "force"`, and `skipLibCheck`, with the rest commented
+out. Run it and delete what does not apply.
+
+Beyond `strict`:
+
+| Flag | What it buys | Cost |
+|---|---|---|
+| `noUncheckedIndexedAccess` | `arr[i]` and `rec[key]` become `T \| undefined`. Removes the largest single source of runtime `undefined`. | Loud. Hundreds of errors in a mature codebase. Adopt in its own commit. |
+| `exactOptionalPropertyTypes` | `{ a?: string }` stops accepting an explicit `a: undefined`, which `"a" in obj` reports as present. | Friction with libraries that spread `undefined` into options objects. |
+| `noImplicitOverride` | A renamed base method no longer silently orphans the subclass override. | Requires the `override` keyword on every override. Mechanical. |
+| `noFallthroughCasesInSwitch` | A missing `break` reads as intentional to everyone but the compiler. | None worth mentioning. |
+| `noPropertyAccessFromIndexSignature` | Forces `obj["key"]` for index-signature access, so a real property and an arbitrary key look different. | Noisy on config objects. Optional. |
+| `noUncheckedSideEffectImports` | A bare `import "./thing"` for a module that does not resolve becomes an error instead of being ignored. | Needs a `.d.ts` shim for the CSS-import-in-TS pattern. |
+| `moduleDetection: "force"` | Every file is a module, so a file with no import is not a script sharing the global scope. | None worth mentioning on new code. |
+| `verbatimModuleSyntax` | Import elision becomes explicit: type-only imports must say `import type`, side-effect imports survive. | Requires a pass over existing imports. Do it during an ESM migration, not after. |
+| `isolatedModules` | Rejects code a single-file transpiler (esbuild, SWC, Babel) cannot handle correctly. | Bans `const enum` re-export and a few ambient patterns. |
+| `erasableSyntaxOnly` (5.8+) | Bans `enum`, `namespace`, and constructor parameter properties, so the code runs under a type-stripping runtime such as recent Node. | Incompatible with NestJS, which needs `emitDecoratorMetadata`. |
+| `noEmit` | The type check does not write output. Correct for anything bundled by Vite, esbuild, or SWC. | None. |
+| `skipLibCheck` | Skips type checking inside `node_modules`. Large compile-time win. | Hides a genuine conflict between two libraries' types. Keep it on anyway; the alternative is unusable. |
+
+`declaration: true` and `declarationMap: true` matter for a published library and nothing else. Turning
+them on in an app costs build time for output nobody reads.
+
+`incremental: true` with a `tsBuildInfoFile` outside `dist` makes the second `tsc --noEmit` several times
+faster. Free.
+
+## Options TypeScript 7 removed
+
+TypeScript 7 is the native (Go) port of the compiler, and it dropped long-deprecated options. A config
+carrying one of these fails to load after the upgrade — a config error, not a type error, so nothing
+builds at all.
+
+| Removed | Replacement |
+|---|---|
+| `baseUrl` | None needed. `paths` resolves relative to the tsconfig on its own (4.4+), so delete `baseUrl` and leave `paths`. For the old catch-all behaviour, `"paths": { "*": ["./*"] }`. |
+| `target: "ES5"` / `"ES3"` | `ES2015` at the oldest. If you genuinely must ship ES5, downlevel with a bundler, not with `tsc`. |
+| `importsNotUsedAsValues` | `verbatimModuleSyntax` |
+| `preserveValueImports` | `verbatimModuleSyntax` |
+| `suppressImplicitAnyIndexErrors` | Fix the index access, or `@ts-expect-error` with a reason |
+
+`experimentalDecorators` and `emitDecoratorMetadata` survive, so NestJS and TypeORM still work.
+
+`scripts/ts-audit.mjs` reports these, because a project that still sets them is one upgrade away from a
+red build and nobody has noticed.
+
+## Which config for which target
+
+The differences that actually matter, rather than a full config per target:
+
+**Bundled front end** (Vite, Next): `"moduleResolution": "bundler"`, `"module": "ESNext"`,
+`"noEmit": true`, `"lib": ["ES2023", "DOM", "DOM.Iterable"]`, `"jsx": "react-jsx"`. The bundler emits;
+`tsc` only checks. `DOM.Iterable` is what makes `for (const el of nodeList)` type-check.
+
+**Node service**: `"module": "NodeNext"`, `"moduleResolution": "nodenext"`, `"lib": ["ES2023"]`,
+`"types": ["node"]`, and `"outDir": "./dist"` if `tsc` is the build. `nodenext` is the only setting that
+models Node's real dual CJS/ESM resolution, including the required file extensions on relative imports.
+
+**Published library**: the Node service settings plus `"declaration": true`, `"declarationMap": true`, and
+`"isolatedDeclarations": true` (5.5+) if the build is not `tsc` — it guarantees every export has an
+inferable type, which is what lets a fast tool emit correct `.d.ts` files.
+
+**Monorepo**: one `tsconfig.base.json` holding the strictness flags, one thin `tsconfig.json` per package
+that extends it. Add project references only when the type check gets slow enough to measure — see below.
+
+Keep `include` narrow (`["src"]`) and let a separate `tsconfig.test.json` cover the tests. A single config
+covering both puts test-only globals in the app's type environment.
+
+## Project references
+
+References let `tsc` treat each package as a separately-cached unit, so touching one leaf does not
+re-check the whole graph. Reach for them when the monorepo's type check is slow enough that you have
+measured it — they add real configuration weight, and `extends` alone covers most repos.
+
+```jsonc
+// tsconfig.json at the root — a solution file. No sources of its own.
+{ "files": [], "references": [{ "path": "./packages/shared" }, { "path": "./packages/api" }] }
+```
+
+```jsonc
+// packages/shared/tsconfig.json — every referenced package
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,      // required; enables the .tsbuildinfo cache
+    "declaration": true,    // consumers read the emitted .d.ts, not your source
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}
+```
+
+```jsonc
+// packages/api/tsconfig.json — a consumer names what it depends on
+{ "extends": "../../tsconfig.base.json", "compilerOptions": { "composite": true },
+  "references": [{ "path": "../shared" }], "include": ["src"] }
+```
+
+The parts that trip people up:
+
+- **Build with `tsc -b`, not `tsc`.** Only build mode walks the reference graph and rebuilds stale
+  projects in order. Plain `tsc -p` on the root does nothing useful, because the root has `"files": []`.
+- **`composite` forces `declaration`,** so a referenced package emits `.d.ts` whether you wanted output or
+  not. A package that only ever gets bundled still pays for the emit.
+- **Consumers see the built `.d.ts`, not the source.** So a stale `dist` shows up as a type error in a
+  package you did not touch. That is the cost of the caching, and `tsc -b --watch` is what makes it
+  bearable in development.
+- **References are not module resolution.** They tell `tsc` about build order; the runtime still needs
+  workspace linking (pnpm workspaces) or a `paths` entry.
+
+## Biome
+
+Biome is one Rust binary that lints and formats. Choosing it means there is no ESLint, no Prettier, and
+no `eslint-config-prettier` reconciling the two — the reason people reach for it is that the whole
+category of config-fighting-config disappears, and it runs fast enough to be a pre-commit hook.
+
+```bash
+pnpm add -D --save-exact @biomejs/biome
+pnpm biome check --write .     # format + lint + organize imports, in one pass
+```
+
+Start from `assets/biome.jsonc`. Three things about it are worth knowing before you write your own.
+
+**Use the `.jsonc` extension.** Biome reads comments in `biome.jsonc`. A comment in `biome.json` makes
+Biome fall back to its defaults **without reporting an error** — severities revert, nursery rules switch
+off, and the formatter goes back to tabs. Nothing tells you. A config that silently does not apply is
+worse than one that fails, so pick the extension that cannot do that.
+
+**Biome does not replace `tsc`.** It has its own type inference, not a type checker. `tsc --noEmit`
+remains the thing that proves your types. Biome's job is the class of bug `tsc` does not model — a
+floating promise above all.
+
+**Ignore patterns come from `.gitignore`** when `vcs.useIgnoreFile` is on, so there is one list instead of
+two. The catch: with that setting and no ignore file, Biome exits with a configuration error rather than a
+warning, which surprises people on a fresh repo.
+
+Biome 2 renamed a few things that older examples still use. `include`/`ignore` became one `includes` list
+where a `!` prefix excludes, and top-level `organizeImports` became an assist action at
+`assist.actions.source.organizeImports`.
+
+Coming from ESLint and Prettier, let Biome do the translation instead of hand-porting:
+
+```bash
+biome migrate eslint --write
+biome migrate prettier --write
+```
+
+It maps the rules it has equivalents for and leaves the rest, so read the result — the diff is the honest
+report of what Biome does not cover.
+
+## Rules that catch real bugs
+
+Biome's recommended set is decent. These are the additions worth making explicit, with the group each
+belongs to (the group is part of the config path, so getting it wrong means the rule silently does not
+apply):
+
+| Rule | Group | Why |
+|---|---|---|
+| `noFloatingPromises` | `nursery` | An unawaited promise swallows its rejection, so the failure vanishes. The highest-value rule here. |
+| `noMisusedPromises` | `nursery` | An `async` callback passed where `() => void` is expected — an event handler, a `forEach`. The rejection goes nowhere. |
+| `useExhaustiveSwitchCases` | `nursery` | The linter's version of the `never` default arm. |
+| `noUnnecessaryConditions` | `suspicious` | A check the types prove is always true. Either the check is dead or the type is wrong. |
+| `noExplicitAny` | `suspicious` | Defaults to a warning. Make it an error on a new project. |
+| `noTsIgnore` | `suspicious` | Pushes you to `@ts-expect-error`, which expires when the error does. |
+| `noNonNullAssertion` | `style` | Defaults to a warning. |
+| `noEnum` | `style` | An `enum` emits runtime code, is nominally typed, and blocks type-stripping runtimes. |
+| `useImportType` | `style` | Keeps type-only imports out of the runtime graph. Pairs with `verbatimModuleSyntax`. |
+
+### The type-aware rules, and their real limits
+
+The first four need type information, and Biome's inference is its own — not `tsc`'s. Two consequences
+that decide how much you can lean on it:
+
+- **They are still `nursery` as of Biome 2.5**, so they are opt-in by name and their behaviour can change
+  between minor versions. Install with `--save-exact` and pin the version, or a patch bump silently
+  changes what CI rejects.
+- **A `types` domain does not enable them.** Setting `"domains": { "types": "all" }` looks like it should
+  and does not — the nursery rules stay off. Name each rule under `nursery`. This is the mistake worth
+  checking for, because the config looks stricter than it is.
+
+What the inference does and does not reach, measured on Biome 2.5:
+
+| Case | Caught |
+|---|---|
+| Floating promise from a function in the same file | yes |
+| Floating promise from a function imported from another file in the project | yes |
+| `async` callback passed inline where `() => void` is expected | yes |
+| `async` function passed by reference where `() => void` is expected | yes |
+| Promise used as a condition (`if (isReady())`) | yes |
+| `async` handler passed to a DOM API typed by `lib.dom.d.ts` (`el.addEventListener("click", save)`) | **no** |
+
+The last row is the honest limit: inference over your own source is solid, inference that depends on
+library declaration files is not there yet. So the `addEventListener` and Express-middleware cases —
+exactly where an unhandled rejection hurts most — are still on you and the reviewer. Say `void save()` at
+those call sites deliberately rather than assuming the linter is watching.
+
+If your project's tolerance for unhandled rejections is zero and it is full of framework callbacks,
+typescript-eslint's `no-misused-promises` still covers more. That is the tradeoff Biome asks you to
+accept in exchange for one fast binary and no config reconciliation.
+## Vitest
+
+```ts
+// vitest.config.ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,             // import from "vitest" — explicit beats ambient
+    environment: "node",        // "jsdom" or "happy-dom" for component tests
+    coverage: { provider: "v8", reporter: ["text", "lcov"] },
+    typecheck: { enabled: true },
+  },
+});
+```
+
+`globals: false` is worth the extra import line: it keeps `describe` and `expect` out of the global type
+environment, so nothing in `src/` can accidentally reference a test global and still compile.
+
+Vitest handles TypeScript and ESM natively, which removes the transform configuration that makes a Jest
+setup fragile. On an existing Jest project, leave it — a migration is its own task.
+
+Mock only what you cannot run. An in-memory store or a real temporary SQLite database tests the query you
+actually ship; a mocked repository tests your mock. Reach for a mock at the true edges: a paid third-party
+API, a clock, a random source.
+
+## Testing types
+
+A type is behaviour, so assert it rather than hoping.
+
+```ts
+import { expectTypeOf, assertType } from "vitest";
+
+expectTypeOf(parseUser).returns.toEqualTypeOf<User>();
+expectTypeOf<CreateUserInput>().not.toHaveProperty("id");
+
+// @ts-expect-error a plain string must not pass where a UserId is required
+cancelOrder(orderId, "not-an-id");
+```
+
+The `@ts-expect-error` form is the strongest test of a branded type or an overload: it fails the build if
+the bad call ever starts compiling, which is exactly the regression you are guarding against.
+
+`typecheck: { enabled: true }` is what makes `expectTypeOf` failures fail the test run rather than being
+silently discarded.
+
+## Vite
+
+```ts
+import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  build: { sourcemap: true },
+});
+```
+
+`vite-tsconfig-paths` makes `tsconfig.json` the single owner of the path aliases. Hand-writing
+`resolve.alias` as well means two mappings that drift, and the failure is a build that type-checks and
+then cannot resolve a module at runtime.
+
+Vite strips types with esbuild and **does not type-check**. `tsc --noEmit` must run separately, in the
+`build` script and in CI. A green `vite build` says nothing about types.
+
+`import.meta.env` needs a declaration for custom variables, or every read is `any`:
+
+```ts
+// src/vite-env.d.ts
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
+```
+
+Only `VITE_`-prefixed variables reach the client bundle. That prefix is a security boundary — anything
+inside it ships to the browser, so a secret with a `VITE_` name is a published secret.
+
+## pnpm
+
+Use `pnpm` when choosing fresh: a content-addressed store makes installs fast and disk use small, and its
+strict `node_modules` layout refuses to resolve a package you did not declare. That strictness is the real
+benefit — npm's flat tree lets a transitive dependency satisfy your import, and the build breaks the day
+that dependency moves.
+
+```yaml
+# pnpm-workspace.yaml
+packages:
+  - "packages/*"
+  - "apps/*"
+```
+
+Use `pnpm add -w` for a root dependency and `--filter <pkg>` to target one workspace package. `pnpm -r`
+runs a script across all of them.
+
+Commit the lockfile. Use `pnpm install --frozen-lockfile` in CI so a stale lockfile fails the build
+instead of quietly resolving something else.
+
+## Formatting
+
+Biome formats, so there is no Prettier. That is most of the appeal: one binary, one config file, and no
+`eslint-config-prettier` layer whose job is to stop two tools from undoing each other's work.
+
+One default worth overriding deliberately: **Biome indents with tabs.** Set `formatter.indentStyle`
+explicitly either way. Left implicit, the first person whose editor disagrees produces a whole-file diff
+and buries the real change.
+
+```jsonc
+"formatter": { "indentStyle": "space", "indentWidth": 2, "lineWidth": 100 }
+```
+
+The values do not matter. Having one committed file that decides them does.
+
+`biome check --write` formats, lints with safe fixes, and sorts imports in one pass, which is what makes
+it viable as a pre-commit hook rather than a CI-only step.
+
+## When the type check gets slow
+
+"Simplify the expensive type" is only actionable once you know which one it is. `tsc` will tell you.
+
+```bash
+tsc --noEmit --extendedDiagnostics     # where the time goes, and how many types were made
+tsc --noEmit --generateTrace .trace    # per-file, per-type timing
+npx @typescript/analyze-trace .trace   # ranks the hot spots from that trace
+tsc --noEmit --explainFiles            # why a file is in the program at all
+```
+
+Read `--extendedDiagnostics` first, because it costs nothing and usually answers the question:
+
+- **`Instantiations` in the millions** — a generic or conditional type is being expanded far more than you
+  think. This is the number that correlates with an unusable editor. Find it with the trace.
+- **`Files` far larger than your source tree** — you are pulling in type packages you do not use. `types`
+  in tsconfig, or `--explainFiles`, will show who dragged them in.
+- **`Check time` dominating** — real type work. **`Parse time` dominating** — too many files, not too many
+  types, and `include` is probably too wide.
+
+Two structural fixes before you start deleting types: narrow `include`, and set `"types": []` so ambient
+`@types` packages are opt-in rather than everything in `node_modules/@types`.
+
+`type-coverage` gives a single percentage of expressions with a non-`any` type, and
+`type-coverage --at-least 95` gates it in CI, which is a useful ratchet during a migration. One caveat
+worth knowing before you add it: it drives the old compiler API, so it **crashes on TypeScript 7** and
+needs the 5.x line. `scripts/ts-audit.mjs` in this skill covers similar ground by counting escape hatches
+directly, with no compiler-API dependency.
+
+## Scripts and CI
+
+```json
+{
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "fix": "biome check --write .",
+    "test": "vitest run",
+    "build": "tsc --noEmit && vite build",
+    "check": "pnpm typecheck && pnpm lint && pnpm test"
+  }
+}
+```
+
+In CI, `biome ci .` instead of `biome check .` — same checks, but it never writes and its output is shaped
+for a CI log.
+
+All three gates check different things, and none subsumes another: `tsc` proves shapes, Biome proves
+formatting plus the type-aware invariants `tsc` does not model (floating promises above all), tests prove
+behaviour. Run all three before claiming a change works. Biome being fast is not a reason to skip `tsc` —
+they do not overlap.
+
+Run them in that order locally — `tsc` is the fastest to fail and gives the clearest message.
+
+## Publishing a library
+
+```json
+{
+  "type": "module",
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+  },
+  "files": ["dist"],
+  "sideEffects": false
+}
+```
+
+Points that break consumers when they are wrong:
+
+- **`types` must come first** in an `exports` entry. Condition order is significant, and a later `types`
+  is ignored.
+- **`exports` replaces `main`** and makes deep imports fail unless you list them. That is the feature: the
+  subpaths you list are your public API, and everything else stops being one.
+- **`sideEffects: false`** lets bundlers tree-shake. It is a lie if any module mutates global state at
+  import time, and the resulting bug is invisible until a consumer's production build drops the module.
+- **Ship a `.d.ts` generated by your build**, not a hand-written one. A hand-written declaration drifts
+  from the implementation and nothing checks it.
+- Check the published surface with `attw` (`are-the-types-wrong`) and `publint` before the first release.
+  Both catch resolution mistakes that only appear in a consumer's project.

--- a/home/dot_agents/skills/typescript/references/type-system.md
+++ b/home/dot_agents/skills/typescript/references/type-system.md
@@ -1,0 +1,397 @@
+# Type system reference
+
+Companion to `SKILL.md`. Read the section you need.
+
+- [Annotate, or let inference work](#annotate-or-let-inference-work)
+- [`interface` vs `type`](#interface-vs-type)
+- [Unions and intersections](#unions-and-intersections)
+- [Literal and template literal types](#literal-and-template-literal-types)
+- [Narrowing](#narrowing)
+- [Type guards](#type-guards)
+- [Assertion functions](#assertion-functions)
+- [`satisfies`](#satisfies)
+- [`any`, `unknown`, `never`, `void`](#any-unknown-never-void)
+- [`readonly` and `as const`](#readonly-and-as-const)
+- [Function types and overloads](#function-types-and-overloads)
+- [Variance, and the method loophole](#variance-and-the-method-loophole)
+- [Instead of `enum`](#instead-of-enum)
+
+## Annotate, or let inference work
+
+Annotate what other code depends on. Let inference handle the rest.
+
+```ts
+// Annotate: the exported signature is a contract, and inference would leak internals
+export function findUser(id: UserId): Promise<User | undefined> { ... }
+
+// Don't annotate: the annotation adds nothing and drifts
+const count: number = items.length;
+const names: string[] = users.map((u) => u.name);
+```
+
+Return-type annotations on exported functions are worth the keystrokes: they stop an accidental widening
+(a refactor that starts returning `any` from a helper is caught at the function, not at its callers), and
+they make the compiler check the body against your intent instead of inferring your mistake.
+
+Inside a function, prefer inference. An annotation on every local is noise that goes stale.
+
+One exception worth knowing: annotate an empty array or an accumulator, because inference gives you
+`never[]` or `{}`.
+
+```ts
+const errors: string[] = [];        // without the annotation: never[]
+```
+
+## `interface` vs `type`
+
+The practical difference is small, so **follow the file you are editing**. When you are choosing fresh:
+
+| Use | For |
+|---|---|
+| `interface` | Object shapes a consumer may need to augment (declaration merging), class contracts (`implements`), public API surfaces |
+| `type` | Unions, intersections, mapped types, conditional types, tuples, function types, anything not a plain object |
+
+```ts
+interface User {
+  id: UserId;
+  email: string;
+}
+
+type UserRole = "viewer" | "editor" | "admin";
+type UserWithRole = User & { role: UserRole };
+```
+
+`interface` supports declaration merging, which is a feature for a library extension point and a hazard
+everywhere else — two declarations of the same name silently combine. `type` errors on the duplicate,
+which is usually what you want.
+
+## Unions and intersections
+
+```ts
+type Id = string | number;                    // one of
+type Employee = Person & { employeeId: string };  // all of
+```
+
+A union of object types is only useful if you can tell the members apart. That is what a discriminant is
+for — see `SKILL.md`. Without one you end up with `in` checks scattered across the codebase, each of them
+a place a new variant can be missed.
+
+Intersecting two object types with conflicting property types gives you `never` for that property, not an
+error at the declaration. The failure surfaces at the assignment, far from the cause.
+
+## Literal and template literal types
+
+Literal types turn a string parameter into a closed set the compiler checks and the editor completes.
+
+```ts
+type Status = "pending" | "approved" | "rejected";
+type Port = 80 | 443 | 8080;
+
+function setStatus(s: Status) { ... }
+setStatus("aproved");   // caught at compile time, not in a support ticket
+```
+
+Template literal types compose them:
+
+```ts
+type Method = "get" | "post";
+type Route = `/api/${string}`;
+type Endpoint = `${Uppercase<Method>} ${Route}`;   // "GET /api/users" | "POST /api/..."
+
+type EventName<T extends string> = `on${Capitalize<T>}`;
+type ClickHandler = EventName<"click">;            // "onClick"
+```
+
+`Uppercase`, `Lowercase`, `Capitalize`, and `Uncapitalize` are built in. They are useful for deriving one
+naming convention from another (a snake_case wire format from a camelCase model, say) without writing the
+second list by hand — and a derived list cannot drift.
+
+Do not go further than the problem needs. A template literal type that parses a URL is impressive and
+unmaintainable. Parse the URL at runtime and return a typed object.
+
+## Narrowing
+
+The hierarchy from `SKILL.md`, with the syntax for each rung.
+
+**1. Discriminant.** The compiler does the work, and exhaustiveness is checkable.
+
+```ts
+switch (shape.kind) {
+  case "circle": return Math.PI * shape.radius ** 2;   // radius exists here
+  case "rect":   return shape.width * shape.height;
+}
+```
+
+**2. `in`.** Narrows to the union members that declare the key.
+
+```ts
+if ("radius" in shape) return Math.PI * shape.radius ** 2;
+```
+
+**3. `typeof` and `instanceof`.** For primitives and class instances.
+
+```ts
+function fmt(v: string | number | Date): string {
+  if (typeof v === "string") return v.trim();
+  if (v instanceof Date) return v.toISOString();
+  return v.toFixed(2);
+}
+```
+
+`typeof null === "object"` — the JavaScript wart the compiler cannot save you from. Check `!== null`
+explicitly before treating a value as an object.
+
+**4. Truthiness and equality.** Cheap and effective, with one trap:
+
+```ts
+if (count) { ... }        // excludes 0 and "" as well as null/undefined
+if (count != null) { ... }  // excludes only null and undefined — usually what you meant
+```
+
+**5. Discriminated returns.** `Array.isArray`, `Number.isInteger`, and friends carry predicate signatures.
+
+Since TypeScript 5.5, a function that plainly returns a boolean expression gets an inferred type
+predicate, so a small helper narrows without an explicit `x is T`:
+
+```ts
+const isDefined = <T,>(x: T | undefined) => x !== undefined;
+const defined = values.filter(isDefined);   // T[], no annotation needed
+```
+
+## Type guards
+
+Write one when the rungs above cannot express the check. It must actually verify the claim: a guard whose
+body does not prove its signature is worse than `as`, because the lie now has a trustworthy name and
+propagates to every caller.
+
+```ts
+// Honest
+function isCircle(s: Shape): s is Extract<Shape, { kind: "circle" }> {
+  return s.kind === "circle";
+}
+
+// A lie. Compiles, narrows, and is wrong for `{}`.
+function isUser(v: unknown): v is User {
+  return typeof v === "object";
+}
+```
+
+For validating unknown input, prefer a schema library over a hand-written guard. A hand-written guard for
+a ten-field object is ten chances to forget a field, and nothing checks it against the type.
+
+```ts
+// Do this instead of a hand-rolled `isUser`
+const UserSchema = z.object({ id: z.string().uuid(), email: z.string().email() });
+type User = z.infer<typeof UserSchema>;
+```
+
+Name guards `isX` or `hasX`. Anything else reads as a normal predicate and the narrowing surprises the
+reader.
+
+## Assertion functions
+
+An assertion signature narrows for the rest of the scope instead of inside a block. Useful for invariants
+and preconditions.
+
+```ts
+function assertDefined<T>(v: T | null | undefined, label: string): asserts v is T {
+  if (v == null) throw new Error(`${label} is required`);
+}
+
+const user = users.get(id);
+assertDefined(user, "user");
+user.email;     // narrowed from here on
+```
+
+Two constraints the compiler enforces loosely and you must respect: an assertion function must be
+annotated explicitly (inference will not produce an `asserts` signature), and it must be called on a
+`const` or `readonly` binding for the narrowing to survive.
+
+Prefer strengthening the input type over asserting at the top of a function. An `assertDefined` on the
+first line of a function usually means the parameter should not have been optional.
+
+## `satisfies`
+
+`satisfies` checks a value against a type without widening it to that type.
+
+```ts
+type Config = Record<string, string | number>;
+
+const a = { theme: "dark", cols: 3 } as Config;
+a.theme;              // string | number — the literal is gone, and `a.missing` also type-checks
+
+const b = { theme: "dark", cols: 3 } satisfies Config;
+b.theme;              // "dark" — literal preserved, and `b.missing` is an error
+```
+
+Where it earns its place:
+
+```ts
+// Route table: keys stay literal, so a typo in a lookup is caught
+const routes = {
+  home: "/",
+  user: "/users/:id",
+} satisfies Record<string, `/${string}`>;
+
+type RouteName = keyof typeof routes;   // "home" | "user", derived not duplicated
+```
+
+Rule of thumb: `satisfies` when you want the check *and* the specific type; a plain annotation when you
+want the general type; `as` almost never.
+
+## `any`, `unknown`, `never`, `void`
+
+```ts
+let a: any;        // opts out of checking, transitively, for everything derived from it
+let u: unknown;    // accepts anything, permits nothing until narrowed
+```
+
+`unknown` is the correct type for external input. The compiler then forces the narrowing you were going
+to skip.
+
+```ts
+function handle(input: unknown) {
+  input.foo;                                  // error, correctly
+  if (typeof input === "object" && input !== null && "foo" in input) {
+    input.foo;                                // allowed
+  }
+}
+```
+
+`never` is the empty type: no value has it. Two everyday uses:
+
+```ts
+function fail(msg: string): never { throw new Error(msg); }   // never returns
+
+default: {
+  const _exhaustive: never = value;   // errors if `value` can still be something
+}
+```
+
+`never` also disappears from unions (`string | never` is `string`), which is what makes `Exclude` and
+conditional-type filtering work.
+
+`void` means "the return value is not meaningful", not "returns undefined". That distinction matters at
+callbacks: a `() => void` parameter accepts a function that returns something, which is why
+`arr.forEach(async () => ...)` compiles and then drops your rejections. See the async section of
+`SKILL.md`.
+
+## `readonly` and `as const`
+
+```ts
+function total(items: readonly Item[]): number { ... }   // cannot sort/push the caller's array
+```
+
+`readonly` on a parameter is a cheap, honest signal: this function does not mutate what you gave it.
+It also prevents the classic bug where an in-place `.sort()` reorders data the caller still needs.
+
+`readonly` is shallow. `readonly User[]` still lets you write `users[0].email = "..."`. Use
+`ReadonlyArray<Readonly<User>>` or a deep-readonly type when it matters, and do not pretend otherwise.
+
+```ts
+const STATUSES = ["pending", "approved"] as const;
+type Status = (typeof STATUSES)[number];        // "pending" | "approved"
+```
+
+That pattern gives you one list usable at both runtime (iterate it, render it) and type level. Two
+parallel declarations — an array and a union — drift.
+
+## Function types and overloads
+
+Prefer a union parameter with narrowing over overloads. Overloads are a separate declaration surface: the
+implementation signature is not checked against them the way you would hope, so they can lie.
+
+```ts
+// Prefer
+function parse(input: string | Buffer): Doc {
+  const text = typeof input === "string" ? input : input.toString("utf8");
+  ...
+}
+```
+
+Reach for overloads when the return type genuinely depends on the argument type and a conditional type
+would be worse to read:
+
+```ts
+function query(sql: string, one: true): Promise<Row>;
+function query(sql: string, one?: false): Promise<Row[]>;
+function query(sql: string, one = false): Promise<Row | Row[]> { ... }
+```
+
+Order overloads most specific first — resolution picks the first match, not the best one.
+
+## Variance, and the method loophole
+
+You rarely need the vocabulary, but you do need the one rule it produces.
+
+A function that **returns** `T` is substitutable where a function returning a supertype is expected — a
+`() => Dog` works as a `() => Animal`. A function that **takes** `T` goes the other way: a handler that
+accepts any `Animal` is safe where an `Animal`-specific handler is wanted, but a handler that needs a
+`Dog` is not, because it will be handed cats. `strictFunctionTypes` is the flag that checks this, and it
+is on under `strict`.
+
+Except it is not checked for methods:
+
+```ts
+const takesDog = (d: Dog): void => { void d.breed; };
+
+// Property syntax — checked. This is an error, correctly.
+const a: { handle: (x: Animal) => void } = { handle: takesDog };
+
+// Method syntax — the same unsound assignment, accepted silently.
+const b: { handle(x: Animal): void } = { handle: takesDog };
+```
+
+Method parameters stay bivariant on purpose: `Array<T>` methods would be unusable otherwise. But the
+loophole applies to *every* method declaration, including your own callbacks, and it survives
+`strict: true`.
+
+So: **declare callbacks and handlers with property syntax.** It costs one character and buys the check.
+
+```ts
+// Do
+interface Store { onChange: (next: State) => void }
+
+// Don't — the parameter type is now unchecked
+interface Store { onChange(next: State): void }
+```
+
+Keep method syntax for actual methods on classes and interfaces meant to be implemented, where you want
+the bivariance and overload merging. The distinction is only about function-valued *properties*.
+
+The other hole is mutable properties, and it goes the opposite way from what you might expect. A sound
+type system would treat `Box<T>` as invariant; TypeScript checks properties covariantly and accepts the
+assignment, which means the write that follows is unchecked:
+
+```ts
+interface Box<T> { value: T }
+
+const asAnimal: Box<Animal> = dogBox;      // accepted — properties are covariant
+asAnimal.value = someAnimal;               // accepted — a plain Animal is now in a Box<Dog>
+const breed: string = dogBox.value.breed;  // typed string, undefined at runtime
+```
+
+No flag turns that off. Marking the field `readonly` does not change assignability — it was already
+allowed — but it blocks the write that makes it unsound, which is the part you can control. So a generic
+container that is only ever read should say so.
+
+## Instead of `enum`
+
+```ts
+// Don't. Emits runtime code, is nominally typed, and cannot be erased by a
+// type-stripping runtime (so `erasableSyntaxOnly` rejects it).
+enum Status { Pending = "pending", Approved = "approved" }
+
+// Do. Same ergonomics, zero runtime cost beyond the object you asked for.
+const Status = {
+  Pending: "pending",
+  Approved: "approved",
+} as const;
+type Status = (typeof Status)[keyof typeof Status];
+```
+
+If you only need the values and never the named constants, the literal union alone is enough — do not
+build the object for nothing.
+
+Numeric `enum`s are worse still: they accept any `number` at assignment in older TypeScript versions, and
+their reverse mapping puts values in the object that were never declared.

--- a/home/dot_agents/skills/typescript/scripts/ts-audit.mjs
+++ b/home/dot_agents/skills/typescript/scripts/ts-audit.mjs
@@ -280,14 +280,19 @@ function scan(files) {
   return { totals, docs, srcFiles, testFiles, lines };
 }
 
-// --- biome ----------------------------------------------------------------
+// --- lint config ----------------------------------------------------------
 
-// The type-aware rules are the reason to run a linter on top of tsc, and they
-// are nursery, so they are off unless named individually. A `types` domain does
-// not turn them on, which makes a config look stricter than it is.
+// These three are the reason to run a linter on top of tsc, and no Ultracite
+// preset enables any of them — Ultracite avoids nursery rules on purpose
+// (haydenbleasel/ultracite#457). They are also off in a bare Biome config
+// unless named individually, and a `types` domain does not turn them on. So a
+// config can look comprehensive and still miss every unhandled rejection.
 const TYPE_AWARE = ["noFloatingPromises", "noMisusedPromises", "useExhaustiveSwitchCases"];
 
-function reportBiome() {
+const UC_CORE = "ultracite/biome/core";
+const UC_TYPE_AWARE = "ultracite/biome/type-aware";
+
+function reportLint(pkg) {
   const jsonc = join(root, "biome.jsonc");
   const json = join(root, "biome.json");
   const file = existsSync(jsonc) ? jsonc : existsSync(json) ? json : null;
@@ -297,40 +302,70 @@ function reportBiome() {
   );
 
   if (file === null) {
-    if (stale.length > 0) console.log(`biome         absent; still carrying ${stale.join(", ")}\n`);
+    if (stale.length > 0) console.log(`lint          absent; still carrying ${stale.join(", ")}\n`);
     return;
   }
 
   const raw = readFileSync(file, "utf8");
-  console.log(`biome         ${basename(file)}`);
 
   // A comment in biome.json makes Biome fall back to defaults and say nothing,
   // so the whole config below is decorative. This is the loudest thing here.
-  if (file === json && /^\s*(\/\/|\/\*)/m.test(raw)) {
-    console.log("  !! this file has comments, and Biome silently ignores a commented biome.json.");
-    console.log("     Nothing in it is applying. Rename it to biome.jsonc.");
-  }
+  const commentedJson = file === json && /^\s*(\/\/|\/\*)/m.test(raw);
 
   let cfg;
   try {
     cfg = parseJsonc(raw);
   } catch (e) {
-    console.log(`  ! cannot parse: ${e.message}\n`);
+    console.log(`lint          ${basename(file)}\n  ! cannot parse: ${e.message}\n`);
     return;
+  }
+
+  const ext = [cfg.extends ?? []].flat();
+  const onUltracite = ext.includes(UC_CORE);
+  console.log(`lint          ${basename(file)}${onUltracite ? " — extends ultracite" : ""}`);
+
+  if (commentedJson) {
+    console.log("  !! this file has comments, and Biome silently ignores a commented biome.json.");
+    console.log("     Nothing in it is applying. Rename it to biome.jsonc.");
+  }
+
+  if (onUltracite) {
+    // Biome resolves `extends` from the project node_modules, so a config that
+    // names a preset the project has not installed fails to load outright.
+    const deps = { ...pkg?.dependencies, ...pkg?.devDependencies };
+    if (deps.ultracite === undefined) {
+      console.log(`  !! extends ${UC_CORE} but ultracite is not a dependency. Biome cannot`);
+      console.log("     load this config. An `npx ultracite` call does not install it.");
+    }
+    if (!ext.includes(UC_TYPE_AWARE)) {
+      console.log(`  ${UC_TYPE_AWARE} not extended — no import-cycle or unresolved-import rules.`);
+    }
+    const presets = ext.filter((e) => e !== UC_CORE && e !== UC_TYPE_AWARE);
+    if (presets.length > 0) console.log(`  presets: ${presets.join(", ")}`);
+    // The nestjs preset switches four rules off, one of which this skill argues for.
+    if (presets.includes("ultracite/biome/nestjs")) {
+      console.log("  note: the nestjs preset turns noEnum off. Literal unions are not enforced here.");
+    }
+  } else {
+    console.log(`  not extending ${UC_CORE} — this config carries every rule by hand.`);
   }
 
   const nursery = cfg.linter?.rules?.nursery ?? {};
   const off = TYPE_AWARE.filter((r) => nursery[r] === undefined || nursery[r] === "off");
   console.log(
     off.length === 0
-      ? "  type-aware rules: all enabled"
-      : `  type-aware rules OFF: ${off.join(", ")} — name them under linter.rules.nursery`,
+      ? "  floating-promise rules: all enabled"
+      : `  floating-promise rules OFF: ${off.join(", ")}`,
   );
+  if (off.length > 0) {
+    console.log("     Name them under linter.rules.nursery. No Ultracite preset enables them.");
+  }
 
   if (cfg.linter?.domains?.types !== undefined && off.length > 0) {
     console.log('  note: a "types" domain does not enable the nursery rules. Name each rule.');
   }
-  if (cfg.formatter?.indentStyle === undefined) {
+  // Ultracite core sets the formatter, so an unset indentStyle is correct there.
+  if (!onUltracite && cfg.formatter?.indentStyle === undefined) {
     console.log("  formatter.indentStyle is unset — Biome defaults to tabs. Say which you want.");
   }
   if (stale.length > 0) {
@@ -355,7 +390,7 @@ function main() {
   const pkg = readJsonIfPresent(join(root, "package.json"));
   if (pkg !== null) {
     const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-    const named = ["typescript", "@biomejs/biome", "vitest", "jest", "zod", "react", "@nestjs/core"]
+    const named = ["typescript", "ultracite", "@biomejs/biome", "vitest", "jest", "zod", "react", "@nestjs/core"]
       .filter((d) => deps[d] !== undefined)
       .map((d) => `${d}@${deps[d]}`);
     console.log(`package.json  type: ${pkg.type ?? "commonjs"}`);
@@ -363,7 +398,7 @@ function main() {
     console.log("");
   }
 
-  reportBiome();
+  reportLint(pkg);
 
   const configPath = join(root, "tsconfig.json");
   if (!existsSync(configPath)) {

--- a/home/dot_agents/skills/typescript/scripts/ts-audit.mjs
+++ b/home/dot_agents/skills/typescript/scripts/ts-audit.mjs
@@ -1,0 +1,483 @@
+#!/usr/bin/env node
+//
+// ts-audit — report a TypeScript project's strictness gaps and escape-hatch
+// density. Node only, no dependencies, read-only.
+//
+//   node ts-audit.mjs [project-dir]        # defaults to the current directory
+//
+// Why this exists: "is this codebase strict?" and "how much `any` is in here?"
+// are questions worth answering with a measurement instead of a guess. The
+// answer decides whether adding types to a module is a 20-minute job or a
+// migration.
+//
+// The flag report is exact — it resolves the `extends` chain. The escape-hatch
+// counts are heuristic: comments and string literals are stripped first, but a
+// regex is not a parser. Treat them as a magnitude, not a total.
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, dirname, resolve, relative, basename } from "node:path";
+
+const root = resolve(process.argv[2] ?? ".");
+
+const STRICT_GROUP = [
+  "noImplicitAny",
+  "strictNullChecks",
+  "strictFunctionTypes",
+  "strictBindCallApply",
+  "strictPropertyInitialization",
+  "strictBuiltinIteratorReturn",
+  "noImplicitThis",
+  "useUnknownInCatchVariables",
+  "alwaysStrict",
+];
+
+const BEYOND_STRICT = [
+  ["noUncheckedIndexedAccess", "arr[i] becomes T | undefined"],
+  ["exactOptionalPropertyTypes", "a?: string stops accepting an explicit undefined"],
+  ["noImplicitOverride", "a renamed base method cannot orphan an override"],
+  ["noFallthroughCasesInSwitch", "a missing break is an error, not a shrug"],
+  ["noImplicitReturns", "every code path returns a value"],
+  ["noUncheckedSideEffectImports", "a bare import of a missing module is an error"],
+  ["verbatimModuleSyntax", "import elision is explicit"],
+  ["isolatedModules", "single-file transpilers stay correct"],
+  ["noUnusedLocals", "dead locals fail the build"],
+  ["noUnusedParameters", "dead parameters fail the build"],
+];
+
+// Options TypeScript 7 removed. A config carrying one of these fails the build
+// on an upgrade, so it is worth reporting even though it is not a strictness gap.
+const REMOVED = [
+  ["baseUrl", 'removed in TS 7 — `paths` resolves relative to the tsconfig without it'],
+  ["importsNotUsedAsValues", "removed — use `verbatimModuleSyntax`"],
+  ["preserveValueImports", "removed — use `verbatimModuleSyntax`"],
+  ["suppressImplicitAnyIndexErrors", "removed — fix the index access or use `// @ts-expect-error`"],
+];
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  "out",
+  ".next",
+  "coverage",
+  ".git",
+  ".turbo",
+  ".output",
+]);
+
+const SOURCE_EXT = /\.(ts|tsx|mts|cts)$/;
+const TEST_FILE = /(\.|-)(test|spec)\.[cm]?tsx?$/;
+
+// --- tsconfig -------------------------------------------------------------
+
+// JSON with comments and trailing commas. Reuse the source stripper, then drop
+// the trailing commas the JSON parser rejects.
+function parseJsonc(text) {
+  return JSON.parse(stripCommentsAndStrings(text, { keepStrings: true }).replace(/,(\s*[}\]])/g, "$1"));
+}
+
+// A config this script could not read makes every flag below read as "off",
+// which would be a lie. Track it and say so.
+let unreadable = 0;
+
+// Resolves `extends` depth-first so a base config's flags are visible, with the
+// nearer config winning. Returns { options, chain }.
+function loadTsconfig(file, seen = new Set()) {
+  const abs = resolve(file);
+  if (seen.has(abs)) return { options: {}, chain: [] };
+  seen.add(abs);
+
+  let raw;
+  try {
+    raw = parseJsonc(readFileSync(abs, "utf8"));
+  } catch (e) {
+    console.error(`  ! cannot parse ${relative(root, abs)}: ${e.message}`);
+    unreadable++;
+    return { options: {}, chain: [abs] };
+  }
+
+  let options = {};
+  let chain = [];
+
+  for (const parent of [raw.extends].flat().filter((v) => typeof v === "string")) {
+    const target = resolveExtends(parent, dirname(abs));
+    if (target === null) {
+      console.error(`  ! cannot resolve extends "${parent}" from ${relative(root, abs)}`);
+      continue;
+    }
+    const base = loadTsconfig(target, seen);
+    options = { ...options, ...base.options };
+    chain = [...chain, ...base.chain];
+  }
+
+  return {
+    options: { ...options, ...(raw.compilerOptions ?? {}) },
+    chain: [...chain, abs],
+  };
+}
+
+function resolveExtends(spec, from) {
+  const candidates = spec.startsWith(".")
+    ? [resolve(from, spec), resolve(from, `${spec}.json`)]
+    : [
+        join(root, "node_modules", spec),
+        join(root, "node_modules", `${spec}.json`),
+        join(root, "node_modules", spec, "tsconfig.json"),
+      ];
+  return candidates.find((c) => existsSync(c) && statSync(c).isFile()) ?? null;
+}
+
+// --- source scanning ------------------------------------------------------
+
+// Removes comments and (unless asked to keep them) string and template
+// literal bodies, so counting `any` does not count the word in a sentence.
+// A single pass over the characters — a regex cannot do this correctly.
+function stripCommentsAndStrings(src, { keepStrings = false } = {}) {
+  let out = "";
+  let i = 0;
+
+  while (i < src.length) {
+    const c = src[i];
+    const next = src[i + 1];
+
+    if (c === "/" && next === "/") {
+      while (i < src.length && src[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (i < src.length && !(src[i] === "*" && src[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      const quote = c;
+      let body = c;
+      i++;
+      while (i < src.length && src[i] !== quote) {
+        if (src[i] === "\\") {
+          body += src[i] + (src[i + 1] ?? "");
+          i += 2;
+          continue;
+        }
+        body += src[i];
+        i++;
+      }
+      i++;
+      out += keepStrings ? body + quote : quote + quote;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+
+  return out;
+}
+
+function walk(dir, files = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) walk(full, files);
+    } else if (SOURCE_EXT.test(entry.name) && !entry.name.endsWith(".d.ts")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const HATCHES = [
+  ["any", /\bany\b/g, "opts out of checking, transitively"],
+  ["as (cast)", /\bas\s+(?!const\b)[A-Za-z_$][\w$<>[\].]*/g, "a claim the compiler did not check"],
+  ["! (non-null)", /[\w$)\]]!(?![=])/g, "asserts a fact you may not have established"],
+  ["@ts-ignore", /@ts-ignore/g, "never expires — prefer @ts-expect-error"],
+  ["@ts-expect-error", /@ts-expect-error/g, "expires when the error does; give a reason"],
+  ["biome-ignore", /biome-ignore/g, "check each one has a reason comment"],
+];
+
+// Doc comments over this many content lines do not get read, and go stale
+// invisibly because nothing checks them. The length is usually a symptom: a type
+// too loose to state its own contract, or a function doing too much.
+const DOC_BUDGET = 3;
+
+// Finds /** */ blocks and counts their prose lines, ignoring the delimiters and
+// blank ` *` separators. Counting content rather than raw height is the honest
+// measure — a blank line is not what makes a comment unreadable.
+function docComments(raw) {
+  const found = [];
+  const lines = raw.split("\n");
+  let start = -1;
+  let content = 0;
+
+  for (const [i, line] of lines.entries()) {
+    const text = line.trim();
+    if (start === -1) {
+      if (text.startsWith("/**")) {
+        start = i;
+        content = text.replace(/^\/\*\*+/, "").replace(/\*\/$/, "").trim() === "" ? 0 : 1;
+        if (text.endsWith("*/")) {
+          found.push({ line: start + 1, content });
+          start = -1;
+        }
+      }
+      continue;
+    }
+    // Strip the closing delimiter before the leading asterisks, or a bare `*/`
+    // line leaves a `/` behind and counts as prose.
+    const body = text.replace(/\*\/\s*$/, "").replace(/^\*+/, "").trim();
+    if (body !== "") content++;
+    if (text.endsWith("*/")) {
+      found.push({ line: start + 1, content });
+      start = -1;
+    }
+  }
+  return found;
+}
+
+function scan(files) {
+  const totals = new Map(HATCHES.map(([name]) => [name, { src: 0, test: 0, worst: null }]));
+  const docs = { total: 0, over: 0, worst: null };
+  let srcFiles = 0;
+  let testFiles = 0;
+  let lines = 0;
+
+  for (const file of files) {
+    const isTest = TEST_FILE.test(basename(file));
+    isTest ? testFiles++ : srcFiles++;
+
+    const raw = readFileSync(file, "utf8");
+    lines += raw.split("\n").length;
+    // Suppression comments live in comments, so count them before stripping.
+    const stripped = stripCommentsAndStrings(raw);
+
+    for (const [name, re] of HATCHES) {
+      const target = name.startsWith("@ts-") || name === "biome-ignore" ? raw : stripped;
+      const n = (target.match(re) ?? []).length;
+      if (n === 0) continue;
+
+      const t = totals.get(name);
+      t[isTest ? "test" : "src"] += n;
+      if (!isTest && (t.worst === null || n > t.worst.n)) t.worst = { file, n };
+    }
+
+    for (const doc of docComments(raw)) {
+      docs.total++;
+      if (doc.content <= DOC_BUDGET) continue;
+      docs.over++;
+      if (docs.worst === null || doc.content > docs.worst.content) {
+        docs.worst = { file, line: doc.line, content: doc.content };
+      }
+    }
+  }
+
+  return { totals, docs, srcFiles, testFiles, lines };
+}
+
+// --- biome ----------------------------------------------------------------
+
+// The type-aware rules are the reason to run a linter on top of tsc, and they
+// are nursery, so they are off unless named individually. A `types` domain does
+// not turn them on, which makes a config look stricter than it is.
+const TYPE_AWARE = ["noFloatingPromises", "noMisusedPromises", "useExhaustiveSwitchCases"];
+
+function reportBiome() {
+  const jsonc = join(root, "biome.jsonc");
+  const json = join(root, "biome.json");
+  const file = existsSync(jsonc) ? jsonc : existsSync(json) ? json : null;
+
+  const stale = ["eslint.config.js", "eslint.config.mjs", ".eslintrc.json", ".prettierrc"].filter((f) =>
+    existsSync(join(root, f)),
+  );
+
+  if (file === null) {
+    if (stale.length > 0) console.log(`biome         absent; still carrying ${stale.join(", ")}\n`);
+    return;
+  }
+
+  const raw = readFileSync(file, "utf8");
+  console.log(`biome         ${basename(file)}`);
+
+  // A comment in biome.json makes Biome fall back to defaults and say nothing,
+  // so the whole config below is decorative. This is the loudest thing here.
+  if (file === json && /^\s*(\/\/|\/\*)/m.test(raw)) {
+    console.log("  !! this file has comments, and Biome silently ignores a commented biome.json.");
+    console.log("     Nothing in it is applying. Rename it to biome.jsonc.");
+  }
+
+  let cfg;
+  try {
+    cfg = parseJsonc(raw);
+  } catch (e) {
+    console.log(`  ! cannot parse: ${e.message}\n`);
+    return;
+  }
+
+  const nursery = cfg.linter?.rules?.nursery ?? {};
+  const off = TYPE_AWARE.filter((r) => nursery[r] === undefined || nursery[r] === "off");
+  console.log(
+    off.length === 0
+      ? "  type-aware rules: all enabled"
+      : `  type-aware rules OFF: ${off.join(", ")} — name them under linter.rules.nursery`,
+  );
+
+  if (cfg.linter?.domains?.types !== undefined && off.length > 0) {
+    console.log('  note: a "types" domain does not enable the nursery rules. Name each rule.');
+  }
+  if (cfg.formatter?.indentStyle === undefined) {
+    console.log("  formatter.indentStyle is unset — Biome defaults to tabs. Say which you want.");
+  }
+  if (stale.length > 0) {
+    console.log(`  leftover config from the old toolchain: ${stale.join(", ")}`);
+  }
+  console.log("");
+}
+
+// --- report ---------------------------------------------------------------
+
+function readJsonIfPresent(file) {
+  try {
+    return parseJsonc(readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  console.log(`\nts-audit — ${root}\n`);
+
+  const pkg = readJsonIfPresent(join(root, "package.json"));
+  if (pkg !== null) {
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    const named = ["typescript", "@biomejs/biome", "vitest", "jest", "zod", "react", "@nestjs/core"]
+      .filter((d) => deps[d] !== undefined)
+      .map((d) => `${d}@${deps[d]}`);
+    console.log(`package.json  type: ${pkg.type ?? "commonjs"}`);
+    if (named.length > 0) console.log(`              ${named.join("  ")}`);
+    console.log("");
+  }
+
+  reportBiome();
+
+  const configPath = join(root, "tsconfig.json");
+  if (!existsSync(configPath)) {
+    console.log("No tsconfig.json at the project root. Nothing to audit.\n");
+    return;
+  }
+
+  const { options, chain } = loadTsconfig(configPath);
+  console.log(`config chain  ${chain.map((c) => relative(root, c) || basename(c)).join(" <- ")}\n`);
+
+  if (unreadable > 0) {
+    console.log(
+      `!! ${unreadable} config file(s) in the chain did not parse. Every flag below reads as\n` +
+        "   off because this script could not see it, not because the project turned it off.\n" +
+        "   Read the config by hand, or fix its syntax and run again.\n",
+    );
+  }
+
+  const strict = options.strict === true;
+  console.log(`strict        ${strict ? "on" : "OFF"}`);
+  if (!strict && unreadable === 0) {
+    const set = STRICT_GROUP.filter((f) => options[f] === true);
+    console.log(
+      set.length > 0
+        ? `              ${set.length}/${STRICT_GROUP.length} members set by hand: ${set.join(", ")}`
+        : "              nothing from the strict group is set — this project is unchecked",
+    );
+    console.log("              set `strict: true` rather than listing members; the group grows.");
+  }
+  const overrides = STRICT_GROUP.filter((f) => options[f] === false);
+  if (strict && overrides.length > 0) {
+    console.log(`              turned back off: ${overrides.join(", ")}`);
+  }
+  console.log("");
+
+  const gaps = [];
+  console.log("beyond strict");
+  for (const [flag, why] of BEYOND_STRICT) {
+    const on = options[flag] === true;
+    if (!on) gaps.push(flag);
+    console.log(`  ${on ? "on " : "off"}  ${flag.padEnd(28)} ${why}`);
+  }
+  console.log("");
+
+  const removed = REMOVED.filter(([flag]) => options[flag] !== undefined);
+  const oldTarget = /^es[35]$/i.test(String(options.target ?? ""));
+  if (removed.length > 0 || oldTarget) {
+    console.log("removed options (these fail the build on a TypeScript 7 upgrade)");
+    for (const [flag, why] of removed) console.log(`  ${flag.padEnd(30)} ${why}`);
+    if (oldTarget) console.log(`  ${`target: ${options.target}`.padEnd(30)} removed in TS 7`);
+    console.log("");
+  }
+
+  const files = walk(root);
+  if (files.length === 0) {
+    console.log("No TypeScript source files found outside the skipped directories.\n");
+    return;
+  }
+
+  const { totals, docs, srcFiles, testFiles, lines } = scan(files);
+  console.log(`source        ${srcFiles} src + ${testFiles} test files, ${lines} lines\n`);
+
+  console.log("escape hatches (heuristic; comments and strings stripped)");
+  const perKLoc = (n) => (lines === 0 ? "0" : ((n / lines) * 1000).toFixed(1));
+  for (const [name, , why] of HATCHES) {
+    const t = totals.get(name);
+    const total = t.src + t.test;
+    const worst =
+      t.worst === null ? "" : `  worst: ${relative(root, t.worst.file)} (${t.worst.n})`;
+    console.log(
+      `  ${String(total).padStart(5)}  ${name.padEnd(18)} ` +
+        `src ${String(t.src).padStart(5)}  test ${String(t.test).padStart(4)}  ` +
+        `${perKLoc(t.src).padStart(5)}/kloc  ${why}${worst}`,
+    );
+  }
+  console.log("");
+
+  console.log(`doc comments  ${docs.total} total, ${docs.over} over ${DOC_BUDGET} prose lines`);
+  if (docs.worst !== null) {
+    console.log(
+      `  worst: ${relative(root, docs.worst.file)}:${docs.worst.line} (${docs.worst.content} lines)`,
+    );
+    console.log("  Read the length as a diagnosis, not a style nit: a loose type, a function doing too");
+    console.log("  much, or a subsystem model in the wrong container. Do not just truncate it.");
+  }
+  console.log("");
+
+  console.log("what to do with this");
+  let step = 0;
+  const advise = (text, continuation) => {
+    console.log(`  ${++step}. ${text}`);
+    if (continuation) console.log(`     ${continuation}`);
+  };
+  if (!strict) {
+    advise("`strict: true` first. Everything else is noise until it is on.");
+  } else if (gaps.length > 0) {
+    advise(
+      `${gaps.length} flag(s) available: ${gaps.join(", ")}.`,
+      "Adopt one per commit. noUncheckedIndexedAccess is the loudest and the most useful.",
+    );
+  } else {
+    advise("Compiler flags are already as tight as this report checks.");
+  }
+  const anySrc = totals.get("any").src;
+  const asSrc = totals.get("as (cast)").src;
+  advise(`${anySrc} \`any\` and ${asSrc} \`as\` in src. Each one is a place the compiler was told to stop looking.`);
+  if (docs.over > 0) {
+    advise(
+      `${docs.over} doc comment(s) past ${DOC_BUDGET} lines. Move each surviving fact into a type, a name,` +
+        " a test, or a linked doc.",
+    );
+  }
+  advise("Do not change a compiler flag unless that was the task. Report the gap instead.");
+  console.log("");
+}
+
+main();

--- a/home/dot_claude/skills/symlink_typescript.tmpl
+++ b/home/dot_claude/skills/symlink_typescript.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.agents/skills/typescript


### PR DESCRIPTION
## What this does

Adds a `typescript` skill that holds the strict-TypeScript rules in one place, and wires it into both agent trees. Ultracite is the lint entry point, and Biome is the engine below it.

`SKILL.md` is the entry point. It stays small, and it points to seven reference files:

| File | Contents |
| --- | --- |
| `references/type-system.md` | Strict flags, and illegal states that you cannot represent |
| `references/patterns.md` | Boundary parsing, error types, and module shape |
| `references/generics.md` | Constraints, inference, and the limits of a generic |
| `references/comments.md` | What a type must say in place of a comment |
| `references/react.md` | Props, hooks, and event types |
| `references/nestjs.md` | DTOs, dependency injection, and pipe types |
| `references/toolchain.md` | tsconfig, Ultracite, Vitest, Vite, and pnpm |

## Why Ultracite, and not Biome alone

`ultracite/biome/core` sets about 365 rules to error, and it also sets the formatter, the ignore globs, the import sorting, and the VCS integration. It already sets every rule that this skill argues for: `noExplicitAny`, `noTsIgnore`, `noUnnecessaryConditions`, `noNonNullAssertion`, `noEnum`, `useImportType`, and `noUnusedVariables`.

So `assets/biome.jsonc` drops from a 30-rule hand-written list to one `extends` line, plus only the parts the presets leave out.

```jsonc
{ "extends": ["ultracite/biome/core", "ultracite/biome/type-aware"] }
```

## The gap the presets leave

No Ultracite preset turns on `noFloatingPromises`, `noMisusedPromises`, or `useExhaustiveSwitchCases`. Not `core`, and not `type-aware` either. Ultracite avoids nursery rules on purpose ([ultracite#457](https://github.com/haydenbleasel/ultracite/issues/457)).

Those three are the highest value that a linter adds on top of `tsc`, thus the config names them itself. This is the gap to check on any Ultracite project: the config looks complete at 365 rules, and the three rules that catch an unhandled rejection are still off.

## Two operation notes

Both came from a test of the real tool, and both are in the asset comments:

- **Ultracite must be a dev dependency.** Biome reads `extends` from the project `node_modules`, thus an `npx ultracite` call alone leaves a config that cannot load its own preset.
- **Call the CLI from a package script.** `ultracite check` starts `biome` from `PATH`. A package script puts `node_modules/.bin` there and a direct call does not, thus the direct call fails with `ENOENT`.

A third note is in the docs: `core` sets `vcs.useIgnoreFile`, so a repo with no `.gitignore` makes Biome exit with a configuration error and nothing lints.

## Verification

Tested against a real project with `ultracite@7.10.6` and `@biomejs/biome@2.5.10`:

- `ultracite check` with the shipped asset. `noFloatingPromises` and `useExhaustiveSwitchCases` fire in `src/`.
- The test-file override is load-bearing, and it is not redundant with the preset. Ultracite relaxes `noExplicitAny` for a `__tests__` directory only, and it never relaxes `noNonNullAssertion`. Errors in a colocated test file go from 4 to 3 with the override.
- The `type-aware` preset works. `noUnresolvedImports` reported a missing `vitest`, and it cleared after the install.
- `ultracite doctor` gives 4 passed, 0 warnings, 0 failed.
- `ts-audit.mjs` in four states: the correct config, a config with the gaps, a config that extends a preset it did not install, and a bare Biome config. Each report was right, and the tab warning correctly stops for a config that extends the preset.
- The numbered advice list in `ts-audit.mjs` used hardcoded numbers, and it printed 1, 2, 4 when the doc-comment item did not apply. A counter now gives the number.
- No secret-shaped literal is in the new files.

## Preset notes in the docs

The `nestjs` preset turns `noEnum`, `noUselessConstructor`, `noStaticOnlyClass`, and `noParameterProperties` **off**, because a decorator-driven framework needs all four. That is correct for NestJS, and it also means a NestJS project loses the "no `enum`" rule this skill recommends elsewhere. The docs and `ts-audit.mjs` both say so.