### PR TITLE
Install pinned plugins across coding clients

### DIFF
--- a/home/.chezmoidata/skills.yaml
+++ b/home/.chezmoidata/skills.yaml
@@ -7,6 +7,10 @@ external_skills:
     repo: github/gh-stack
     sha: 14fc42ed9b6c376a53b2f999f138d3bd26dac546
     path: skills/gh-stack
+  skill-creator:
+    repo: anthropics/claude-plugins-official
+    sha: b819188d2eea14e0400556ca29dbd1179a7c595b
+    path: plugins/skill-creator/skills/skill-creator
   shadcn:
     repo: shadcn-ui/ui
     sha: a85299a9edd2a961e32f01ced86963a852652bd2
@@ -15,3 +19,35 @@ external_skills:
     repo: humanlayer/skills
     sha: 3c2629142c5d437428269b1b722b08c0b87f574d
     path: plugins/show-me/skills/show-me
+
+agent_plugins:
+  - name: compound-engineering
+    marketplace: compound-engineering-plugin
+    repo: EveryInc/compound-engineering-plugin
+    sha: 4e6738223d7dd66d765a598673c48c136fb78f95
+    include:
+      - .agents
+      - .agents/plugins
+      - .agents/plugins/**
+      - .claude-plugin
+      - .claude-plugin/**
+      - .codex-plugin
+      - .codex-plugin/**
+      - assets
+      - assets/**
+      - plugin.json
+      - skills
+      - skills/**
+  - name: worktrunk
+    marketplace: worktrunk
+    repo: max-sixty/worktrunk
+    sha: 852f6ea288b360f10bdaab0a4925c255c68f9b50
+    include:
+      - .agents
+      - .agents/plugins
+      - .agents/plugins/**
+      - .claude-plugin
+      - .claude-plugin/**
+      - plugins
+      - plugins/worktrunk
+      - plugins/worktrunk/**

--- a/home/.chezmoiexternals/agent-plugins.toml.tmpl
+++ b/home/.chezmoiexternals/agent-plugins.toml.tmpl
@@ -1,0 +1,13 @@
+# Generated from .chezmoidata/skills.yaml. Edit that file, not this one.
+{{ range $plugin := .agent_plugins }}
+[".agents/{{ $plugin.name }}-plugin"]
+type = "archive"
+# pin: {{ $plugin.repo }}@{{ $plugin.sha }}
+url = "https://github.com/{{ $plugin.repo }}/archive/{{ $plugin.sha }}.tar.gz"
+include = [
+{{- range $path := $plugin.include }}
+  "*/{{ $path }}",
+{{- end }}
+]
+stripComponents = 1
+{{ end }}

--- a/home/.chezmoiscripts/unix/run_after_40-install-agent-plugins.sh.tmpl
+++ b/home/.chezmoiscripts/unix/run_after_40-install-agent-plugins.sh.tmpl
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+{{ range $plugin := .agent_plugins -}}
+# pin: {{ $plugin.repo }}@{{ $plugin.sha }}
+{{ end -}}
+plugin_sources="${HOME}/.agents"
+plugin_revision="{{ range $plugin := .agent_plugins }}{{ $plugin.name }}:{{ $plugin.sha }};{{ end }}"
+state_dir="${XDG_STATE_HOME:-${HOME}/.local/state}/chezmoi-agent-plugins"
+
+needs_install() {
+  local client=$1
+  local marker="${state_dir}/${client}"
+
+  [ ! -f "${marker}" ] || [ "$(cat "${marker}")" != "${plugin_revision}" ]
+}
+
+record_install() {
+  local client=$1
+
+  mkdir -p "${state_dir}"
+  printf '%s\n' "${plugin_revision}" >"${state_dir}/${client}"
+}
+
+install_claude_plugins() {
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "Claude Code is not installed. Skip its plugins."
+    return
+  fi
+  if ! needs_install claude; then
+    return
+  fi
+
+{{ range $plugin := .agent_plugins -}}
+  claude plugin marketplace add "${plugin_sources}/{{ $plugin.name }}-plugin"
+  claude plugin install "{{ $plugin.name }}@{{ $plugin.marketplace }}" --scope user
+{{ end }}
+  record_install claude
+}
+
+install_codex_plugins() {
+  if ! command -v codex >/dev/null 2>&1; then
+    echo "Codex is not installed. Skip its plugins."
+    return
+  fi
+  if ! needs_install codex; then
+    return
+  fi
+
+{{ range $plugin := .agent_plugins -}}
+  codex plugin marketplace add "${plugin_sources}/{{ $plugin.name }}-plugin"
+  codex plugin add "{{ $plugin.name }}@{{ $plugin.marketplace }}"
+{{ end }}
+  record_install codex
+}
+
+install_copilot_plugins() {
+  if ! command -v copilot >/dev/null 2>&1; then
+    echo "Copilot CLI is not installed. Skip its plugins."
+    return
+  fi
+  if ! needs_install copilot; then
+    return
+  fi
+
+{{ range $plugin := .agent_plugins -}}
+  copilot plugin marketplace add "${plugin_sources}/{{ $plugin.name }}-plugin"
+  copilot plugin install "{{ $plugin.name }}@{{ $plugin.marketplace }}"
+{{ end }}
+  record_install copilot
+}
+
+install_claude_plugins
+install_codex_plugins
+install_copilot_plugins

--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -110,23 +110,9 @@
   "cleanupPeriodDays": 14,
   "skipWorkflowUsageWarning": true,
   "enabledPlugins": {
-    "compound-engineering@compound-engineering-plugin": true,
-    "skill-creator@claude-plugins-official": true,
-    "worktrunk@worktrunk": true
-  },
-  "extraKnownMarketplaces": {
-    "compound-engineering-plugin": {
-      "source": {
-        "repo": "EveryInc/compound-engineering-plugin",
-        "source": "github"
-      }
-    },
-    "worktrunk": {
-      "source": {
-        "repo": "max-sixty/worktrunk",
-        "source": "github"
-      }
-    }
+{{- range $index, $plugin := .agent_plugins }}
+    {{ if $index }},{{ end }}"{{ $plugin.name }}@{{ $plugin.marketplace }}": true
+{{- end }}
   },
   "permissions": {
     "disableBypassPermissionsMode": "disable",


### PR DESCRIPTION
## TL;DR

Fresh setups could enable plugin names without downloading their code, which left configured workflows unavailable. Pinned archives now provide shared plugin sources, and an idempotent installer registers them with each available coding client.

**Files to review (4, +127 / -17):**

| File | Why |
|---|---|
| Plugin data | Owns repository pins, marketplace names, and the shared skill source. |
| External archive template | Downloads only the manifests, skills, hooks, and assets required at runtime. |
| Plugin installer | Registers local marketplaces and installs plugins for each available client. |
| Client settings template | Generates enabled plugin entries from the shared data. |

## How

One data structure owns each repository, commit SHA, marketplace name, and archive allowlist. Chezmoi materializes those pinned files locally before the installer registers the local marketplaces, so each client receives the same reviewed source instead of the current marketplace head.

Per-client state records the installed revision set. A later `chezmoi apply` skips clients that already match, retries clients that were previously unavailable, and reinstalls plugins after a pin changes.

## Reviewer notes

- **Shared skill:** `skill-creator` uses the existing canonical skill directory and client symlinks because it does not need plugin hooks.
- **Archive scope:** allowlists avoid downloading unrelated source, tests, and build artifacts from the upstream repositories.