### PR TITLE
Pin two frontend design skills in the lockfile

### DIFF
--- a/home/.chezmoidata/skills.yaml
+++ b/home/.chezmoidata/skills.yaml
@@ -19,6 +19,15 @@ external_skills:
     repo: humanlayer/skills
     sha: 3c2629142c5d437428269b1b722b08c0b87f574d
     path: plugins/show-me/skills/show-me
+  impeccable:
+    repo: pbakaus/impeccable
+    sha: 63b04e2530f5c7b41ea83c133daab24f34912456
+    path: .agent/skills/impeccable
+  # The repo holds a roster of skills. Only the flagship one is installed.
+  taste-skill:
+    repo: Leonxlnx/taste-skill
+    sha: ccbc15639c97057cbfcf32ecebc38ef716e4bb37
+    path: skills/taste-skill
 
 agent_plugins:
   - name: compound-engineering

--- a/home/dot_claude/skills/symlink_impeccable.tmpl
+++ b/home/dot_claude/skills/symlink_impeccable.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.agents/skills/impeccable

--- a/home/dot_claude/skills/symlink_taste-skill.tmpl
+++ b/home/dot_claude/skills/symlink_taste-skill.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.agents/skills/taste-skill


### PR DESCRIPTION
## TL;DR

`impeccable` and `taste-skill` arrived through `npx skills add`, which writes
into `~/.agents/skills` with no pin, thus a new machine does not get them and
an update is not reproducible. Both skills now sit in
`home/.chezmoidata/skills.yaml` behind a commit SHA, each with a symlink into
`~/.claude/skills`.

## Reviewer notes

- **`taste-skill` is one skill out of a roster of 12.** The upstream repo also
  ships `brandkit`, `redesign-skill`, and 9 more. Only `skills/taste-skill` is
  in scope.
- **The frontmatter name does not match the directory.** `taste-skill` declares
  `name: design-taste-frontend`. The loader uses the directory name, thus the
  skill appears as `taste-skill`.

`chezmoi apply --refresh-externals` runs clean, and both skills load.
