### PR TITLE
Stop the settings.json diff, and clean the skill links

### DIFF
--- a/home/.chezmoiscripts/unix/run_onchange_after_20-link-external-skills.sh.tmpl
+++ b/home/.chezmoiscripts/unix/run_onchange_after_20-link-external-skills.sh.tmpl
@@ -14,13 +14,14 @@ fi
 
 canonical="$HOME/.agents/skills"
 
+# Copilot reads $canonical itself, thus only Claude needs the symlinks.
+agent_dir="$HOME/.claude/skills"
+mkdir -p "$agent_dir"
+
 for name in "${skills[@]}"; do
   if [ ! -d "$canonical/$name" ]; then
     echo "external skill '$name' missing from $canonical — check its path in .chezmoidata/skills.yaml" >&2
     exit 1
   fi
-  for agent_dir in "$HOME/.claude/skills" "$HOME/.copilot/skills"; do
-    mkdir -p "$agent_dir"
-    ln -sfn "$canonical/$name" "$agent_dir/$name"
-  done
+  ln -sfn "$canonical/$name" "$agent_dir/$name"
 done

--- a/home/dot_claude/hooks/executable_statusline.sh
+++ b/home/dot_claude/hooks/executable_statusline.sh
@@ -105,13 +105,18 @@ shorten_model() {
 }
 MODEL=$(shorten_model "$raw_model")
 
-# Context window
+# Context window. The bar measures against a fixed budget, not the model window,
+# to keep one scale for all models.
+CTX_LIMIT=350000
+CTX_LIMIT_LABEL="$((CTX_LIMIT / 1000))k"
+
 CTX_PCT=$(jqr '(.context_window.used_percentage // 0) | floor')
 CTX_USED=$(jqr '.context_window.current_tokens // .context_window.used // 0')
 is_num "$CTX_PCT"  || CTX_PCT=0
 is_num "$CTX_USED" || CTX_USED=0
 
-EXCEEDS_200K=$(jqr '.exceeds_200k_tokens // false')
+# Token count is the better signal. Use the reported percentage only without it.
+[ "$CTX_USED" -gt 0 ] && CTX_PCT=$(( CTX_USED * 100 / CTX_LIMIT ))
 
 # Cost (official schema: cost.total_cost_usd; fall back to flat fields for other versions)
 COST_RAW=$(jqr '.cost.total_cost_usd // .cost_usd // .session_cost_usd // 0')
@@ -193,8 +198,8 @@ fi
 [ -n "$OUTPUT_STYLE" ] && PARTS+=("${C_PINK}${OUTPUT_STYLE}${R}")
 
 # Context window
-if [ "$EXCEEDS_200K" = "true" ]; then
-  PARTS+=("${B}${C_RED}████████ 200k+${R}")
+if [ "$CTX_USED" -ge "$CTX_LIMIT" ]; then
+  PARTS+=("${B}${C_RED}████████ ${CTX_LIMIT_LABEL}+${R}")
 elif [ "$CTX_PCT" -ge 95 ]; then
   PARTS+=("${B}${C_RED}████████ ${CTX_PCT}%${R}")
 else

--- a/home/dot_claude/modify_settings.json.tmpl
+++ b/home/dot_claude/modify_settings.json.tmpl
@@ -1,8 +1,19 @@
-{{- /* The Pixoo keys arrive with `chezmoi init`. Keep apply usable before that. */ -}}
-{{- $pixooEnabled := false -}}
-{{- $pixooAddress := "" -}}
-{{- if hasKey . "pixooEnabled" }}{{ $pixooEnabled = .pixooEnabled }}{{ end -}}
-{{- if hasKey . "pixooAddress" }}{{ $pixooAddress = .pixooAddress }}{{ end -}}
+#!/usr/bin/env bash
+# Claude Code rewrites ~/.claude/settings.json in its own key order each time a
+# setting changes. A plain template thus shows a large diff after each change,
+# although the two files hold the same data. This script merges the managed keys
+# into the live file. If the live file is already correct, the script writes it
+# out with no change, thus the key order of Claude Code stays.
+#
+# Keys that Claude Code adds by itself stay in the file. The managed keys below
+# always win.
+set -euo pipefail
+{{ $pixooEnabled := false }}
+{{ $pixooAddress := "" }}
+{{ if hasKey . "pixooEnabled" }}{{ $pixooEnabled = .pixooEnabled }}{{ end }}
+{{ if hasKey . "pixooAddress" }}{{ $pixooAddress = .pixooAddress }}{{ end }}
+managed=$(
+    cat <<'MANAGED_JSON'
 {
   "env": {
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
@@ -420,3 +431,28 @@
     ]
   }
 }
+MANAGED_JSON
+)
+
+current=$(cat)
+
+# `brew bundle` runs after chezmoi writes the files, thus the first apply on a
+# new machine has no jq. Write the managed keys, and merge at the next apply.
+if ! command -v jq >/dev/null 2>&1; then
+    printf '%s\n' "$managed"
+    exit 0
+fi
+
+if ! printf '%s' "$current" | jq -e . >/dev/null 2>&1; then
+    current='{}'
+fi
+
+merged=$(jq -n --argjson cur "$current" --argjson man "$managed" '$cur + $man')
+
+# The live file already holds the managed keys. Keep it, thus the key order of
+# Claude Code makes no diff.
+if [ "$(printf '%s' "$current" | jq -Sc .)" = "$(printf '%s' "$merged" | jq -Sc .)" ]; then
+    printf '%s\n' "$current"
+else
+    printf '%s\n' "$merged"
+fi

--- a/home/dot_config/atuin/config.toml
+++ b/home/dot_config/atuin/config.toml
@@ -203,3 +203,6 @@ enter_accept = true
 # This ensures that sync v2 is enabled for new installs only
 # In a later release it will become the default across the board
 records = true
+
+[ai]
+enabled = true

--- a/home/dot_config/lazygit/config.yml.tmpl
+++ b/home/dot_config/lazygit/config.yml.tmpl
@@ -1,4 +1,4 @@
-{{- $palette := index .catppuccin.palettes .catppuccinFlavor }}
+{{- $palette := index .catppuccin.palettes .catppuccinFlavor -}}
 #reference from https://github.com/scottmckendry/Windots/blob/main/lazygit/config.yml
 notARepository: skip
 disableStartupPopups: true
@@ -36,8 +36,8 @@ gui:
     '*': '{{ $palette.lavender }}'
 git:
   parseEmoji: true
-  pagers:
-    - pager: delta --paging=never
+  diffRenderers:
+    - command: delta --paging=never
       colorArg: always
 customCommands:
   - key: 'E'


### PR DESCRIPTION
## Cause

`chezmoi apply` made a large diff in `~/.claude/settings.json` after each use.
The two files held the same data, and only the key order was different. Claude
Code writes the file in its own key order each time a setting changes, thus the
template and the live file never agreed.

Three smaller items came out of the same audit.

## Changes

| Commit | Change |
|---|---|
| `feat(statusline)` | The context bar uses a fixed budget of 350k, thus all models get one scale. The token count replaces the `exceeds_200k_tokens` flag. |
| `refactor(skills)` | The external-skill script links into `~/.claude/skills` only. Copilot reads `~/.agents/skills` itself. |
| `fix(claude)` | `settings.json` becomes a `modify_` script that merges the managed keys. |
| `chore(config)` | Backport of the `atuin` and `lazygit` drift. |

## How the merge works

The `modify_` script gets the live file on stdin, and merges the managed keys
with `jq`:

```
merged=$(jq -n --argjson cur "$current" --argjson man "$managed" '$cur + $man')
```

The script then compares the live file and the merge result by value. If the
live file already holds the managed keys, the script writes the live file out
with no change. The key order thus makes no diff, and this holds if a later
release of Claude Code changes the order again.

The merge is shallow (`+`), not deep (`*`). A deep merge keeps each managed key
that the template no longer writes. The Pixoo hooks are an example: a deep merge
leaves them in the file after `pixooEnabled` becomes false.

`brew bundle` runs after chezmoi writes the files, thus the first apply on a new
machine has no `jq`. The script writes the managed keys, and merges at the next
apply.

## Test

| Case | Result |
|---|---|
| Live file already correct | Byte-identical output, no diff |
| Same input two times | Stable |
| Empty stdin, that is a new machine | Full managed JSON, valid |
| Claude Code adds a key | The key stays |
| A managed value drifts | The managed value wins |
| Drifted input, second pass | Stable after one apply |

`bash -n` passes on the rendered script. For `atuin` and `lazygit`, the rendered
template and the live file are identical.

## Note

The two backports do not remove the cause. `atuin` and `lazygit` write their own
files, thus the drift comes back. The `modify_` pattern applies to them also.