### PR TITLE
Configure coding agents and repair macOS packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ The `Update pins` workflow does the same each month, and it opens a `pull reques
 `pull request` before the merge. It moves a pin to the upstream head, which can be an untested
 commit, and it does not change the `# pin:` comment.
 
+### OpenCode V2
+
+Chezmoi manages OpenCode V2's global server config, CLI preferences, instructions, and portable
+agents under `~/.config/opencode`. OpenCode discovers the canonical skills in `~/.agents/skills`
+without extra symlinks or a duplicate `skills` config entry. Project-specific guidance belongs in
+an `AGENTS.md`; project-specific providers, MCP servers, and references belong in
+`opencode.jsonc` or `.opencode/opencode.jsonc`.
+
+The global `opencode.jsonc` uses a chezmoi modifier. Add machine-local providers or MCP servers
+directly to `~/.config/opencode/opencode.jsonc`; `chezmoi apply` preserves unrelated top-level
+keys. Chezmoi owns `$schema`, `shell`, `update`, `snapshots`, `watcher`, and `permissions`.
+
 ### 🔀 macOS install profiles (personal vs restricted)
 
 On macOS, Homebrew apps are installed from a templated `Brewfile` that respects a profile:

--- a/home/.chezmoidata/agents.yaml
+++ b/home/.chezmoidata/agents.yaml
@@ -6,9 +6,9 @@
 # that tool's native frontmatter.
 #
 # To add an agent: write the body, add an entry here, then add one two-line
-# wrapper per target under dot_claude/agents, dot_copilot/agents, and
-# dot_codex/agents. To remove one: delete those files and add the destination
-# paths to .chezmoiremove.
+# wrapper per target under dot_claude/agents, dot_copilot/agents,
+# dot_codex/agents, and dot_config/opencode/agents. To remove one: delete those
+# files and add the destination paths to .chezmoiremove.
 #
 # `write` is explicit rather than derived from the Claude tool list, because
 # Codex has no tool allowlist. It expresses permission as a sandbox mode, so
@@ -24,7 +24,7 @@ agents:
       relevant failure links. Use when waiting for CI results or when CI has
       failed. Use proactively to monitor branch CI.
     write: false
-    targets: [claude, copilot, codex]
+    targets: [claude, copilot, codex, opencode]
     claude:
       model: haiku
       tools: Bash
@@ -38,7 +38,7 @@ agents:
       code. Use before review to strip narration, commented-out code, and
       suppression comments, and to flag the symbols that need reshaping.
     write: true
-    targets: [claude, copilot, codex]
+    targets: [claude, copilot, codex, opencode]
     claude:
       model: opus
       tools: Bash, Read, Edit, Glob, Grep
@@ -53,7 +53,7 @@ agents:
       references and concrete rewrites. Does not rewrite the document. Use for
       RFC drafts, PR descriptions, design docs, and any prose others will read.
     write: false
-    targets: [claude, copilot, codex]
+    targets: [claude, copilot, codex, opencode]
     claude:
       model: opus
       tools: Read, Grep
@@ -68,7 +68,7 @@ agents:
       disbelief, and the burden of proof sits on the claim. Use for RFC
       validation, design critique, and code correctness verification.
     write: false
-    targets: [claude, copilot, codex]
+    targets: [claude, copilot, codex, opencode]
     claude:
       model: opus
       tools: Bash, Read, Glob, Grep
@@ -82,7 +82,7 @@ agents:
       idiomatic style. Use when new logic needs coverage, when a bug needs a
       regression test, or when existing tests are weak or missing.
     write: true
-    targets: [claude, copilot, codex]
+    targets: [claude, copilot, codex, opencode]
     claude:
       model: sonnet
       tools: Read, Write, Edit, Grep, Glob, Bash
@@ -98,7 +98,7 @@ agents:
       API endpoints, or sensitive data. Flags secrets, SSRF, injection, unsafe
       crypto, and OWASP Top 10 vulnerabilities.
     write: true
-    targets: [claude, copilot, codex]
+    targets: [claude, copilot, codex, opencode]
     claude:
       model: opus
       tools: Read, Write, Edit, Bash, Grep, Glob

--- a/home/.chezmoiscripts/unix/run_onchange_after_20-link-external-skills.sh.tmpl
+++ b/home/.chezmoiscripts/unix/run_onchange_after_20-link-external-skills.sh.tmpl
@@ -14,7 +14,8 @@ fi
 
 canonical="$HOME/.agents/skills"
 
-# Copilot reads $canonical itself, thus only Claude needs the symlinks.
+# Copilot and OpenCode V2 read $canonical themselves, thus only Claude needs
+# the symlinks.
 agent_dir="$HOME/.claude/skills"
 mkdir -p "$agent_dir"
 

--- a/home/.chezmoiscripts/unix/run_onchange_after_35-install-opencode-plugin-dependencies.sh.tmpl
+++ b/home/.chezmoiscripts/unix/run_onchange_after_35-install-opencode-plugin-dependencies.sh.tmpl
@@ -3,9 +3,9 @@ set -euo pipefail
 
 # package hash: {{ include (joinPath .chezmoi.sourceDir "dot_config/opencode/package.json") | sha256sum }}
 
-if ! command -v bun >/dev/null 2>&1; then
-  echo "bun is required to install OpenCode plugin dependencies" >&2
+if ! command -v mise >/dev/null 2>&1; then
+  echo "mise is required to install OpenCode plugin dependencies" >&2
   exit 1
 fi
 
-bun install --cwd "${HOME}/.config/opencode"
+mise exec -- bun install --cwd "${HOME}/.config/opencode"

--- a/home/.chezmoiscripts/unix/run_onchange_after_35-install-opencode-plugin-dependencies.sh.tmpl
+++ b/home/.chezmoiscripts/unix/run_onchange_after_35-install-opencode-plugin-dependencies.sh.tmpl
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# package hash: {{ include (joinPath .chezmoi.sourceDir "dot_config/opencode/package.json") | sha256sum }}
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is required to install OpenCode plugin dependencies" >&2
+  exit 1
+fi
+
+bun install --cwd "${HOME}/.config/opencode"

--- a/home/.chezmoitemplates/agents/agent-opencode.tmpl
+++ b/home/.chezmoitemplates/agents/agent-opencode.tmpl
@@ -1,0 +1,28 @@
+{{- /*
+Renders a complete OpenCode V2 subagent file for ~/.config/opencode/agents.
+Call with (dict "ctx" . "id" "<agent-id>" "body" <rendered body>).
+
+OpenCode agents inherit the active session model so they work with any provider.
+The portable registry's write flag and Claude shell allowlist provide the
+permission metadata that maps cleanly to OpenCode.
+*/ -}}
+{{- $a := index .ctx.agents .id -}}
+---
+description: {{ $a.description | quote }}
+mode: subagent
+{{- if or (not $a.write) (not (contains "Bash" $a.claude.tools)) }}
+permissions:
+{{- if not $a.write }}
+  - action: edit
+    resource: "*"
+    effect: deny
+{{- end }}
+{{- if not (contains "Bash" $a.claude.tools) }}
+  - action: shell
+    resource: "*"
+    effect: deny
+{{- end }}
+{{- end }}
+---
+
+{{ .body }}

--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -30,7 +30,7 @@ cask "visual-studio-code"
 cask "clocker" # Menubar World Clock
 cask "notion"
 cask "netnewswire"
-cask "transmission"
+cask "homebrew/cask/transmission"
 {{- end }}
 
 
@@ -60,7 +60,6 @@ cask "iina"
 # DEVELOPMENT #
 cask "docker-desktop"
 cask "ghostty"
-cask "alacritty"
 # GitHub Copilot CLI. Must stay a cask: the unqualified formula name resolves to
 # aws/tap/copilot-cli, which is AWS's unrelated container-deploy tool.
 cask "copilot-cli"

--- a/home/dot_codex/modify_private_config.toml
+++ b/home/dot_codex/modify_private_config.toml
@@ -13,20 +13,26 @@ overlay_file=$(mktemp "${TMPDIR:-/tmp}/codex-config.XXXXXX")
 trap 'rm -f "$overlay_file"' EXIT HUP INT TERM
 
 cat >"$overlay_file" <<'EOF'
-# Match the default Claude Code posture: work freely in the current project,
-# request approval for elevated actions, and keep network access disabled.
+# Work freely in trusted projects, protect home-level credentials, and request
+# approval for elevated shell commands and state-changing app actions.
 approval_policy = "on-request"
 default_permissions = "project-workspace"
-web_search = "disabled"
+web_search = "indexed"
 allow_login_shell = true
 
 [permissions.project-workspace]
-description = "Workspace editing with secret files and network access denied."
+description = "Trusted workspace editing with approval-gated network access."
 extends = ":workspace"
 
 [permissions.project-workspace.filesystem]
 glob_scan_max_depth = 8
-"~/.ssh" = "deny"
+"~/.ssh" = "read"
+"~/.ssh/id_dsa" = "deny"
+"~/.ssh/id_ecdsa" = "deny"
+"~/.ssh/id_ecdsa_sk" = "deny"
+"~/.ssh/id_ed25519" = "deny"
+"~/.ssh/id_ed25519_sk" = "deny"
+"~/.ssh/id_rsa" = "deny"
 "~/.aws" = "deny"
 "~/.config/gcloud" = "deny"
 "~/.kube" = "deny"
@@ -36,27 +42,10 @@ glob_scan_max_depth = 8
 "~/vault-token" = "deny"
 
 [permissions.project-workspace.filesystem.":workspace_roots"]
-".env" = "deny"
-".env.*" = "deny"
-"**/.env" = "deny"
-"**/.env.*" = "deny"
-"secrets/**" = "deny"
-"**/secrets/**" = "deny"
-"**/*.pem" = "deny"
-"**/*.key" = "deny"
-"**/*.p12" = "deny"
-"**/*.pfx" = "deny"
-"**/*.cer" = "deny"
-"**/*.crt" = "deny"
-"**/id_rsa" = "deny"
-"**/id_ed25519" = "deny"
-"**/vault-token" = "deny"
-"**/.netrc" = "deny"
-"**/.npmrc" = "deny"
-"**/.pypirc" = "deny"
+".git" = "write"
 
 [permissions.project-workspace.network]
-enabled = false
+enabled = true
 
 [shell_environment_policy]
 inherit = "all"
@@ -64,8 +53,8 @@ ignore_default_excludes = false
 
 [apps._default]
 default_tools_approval_mode = "writes"
-destructive_enabled = false
-open_world_enabled = false
+destructive_enabled = true
+open_world_enabled = true
 
 [analytics]
 enabled = false
@@ -87,5 +76,10 @@ EOF
 yq eval-all \
     --input-format toml \
     --output-format toml \
-    '. as $item ireduce ({}; . * $item) | del(.sandbox_mode, .sandbox_workspace_write)' \
-    - "$overlay_file"
+    '. as $item ireduce ({}; . * $item)' \
+    - "$overlay_file" | \
+    yq eval \
+        --input-format toml \
+        --output-format toml \
+        'del(.sandbox_mode, .sandbox_workspace_write) |
+        .permissions."project-workspace".filesystem.":workspace_roots" = {".git": "write"}'

--- a/home/dot_codex/rules/default.rules
+++ b/home/dot_codex/rules/default.rules
@@ -3,7 +3,7 @@
 # Commands not listed here still run inside the selected permission profile.
 # These rules only decide whether a command may escape that sandbox.
 
-# Privilege escalation and destructive system administration are forbidden.
+# Privilege escalation and catastrophic system administration are forbidden.
 forbidden_commands = [
     ["sudo"],
     ["su"],
@@ -12,14 +12,6 @@ forbidden_commands = [
     ["runas"],
     ["mkfs"],
     ["diskutil", "eraseDisk"],
-    ["dd"],
-    ["shred"],
-    ["launchctl"],
-    ["systemctl"],
-    ["service"],
-    ["crontab"],
-    ["at"],
-    ["chown"],
     ["visudo"],
     ["passwd"],
 ]
@@ -31,8 +23,9 @@ for command in forbidden_commands:
         justification = "This command is blocked by the global Codex safety policy.",
     )
 
-# Direct network, remote-access, cloud, and infrastructure clients are blocked.
-forbidden_network_commands = [
+# Direct network, remote-access, cloud, and infrastructure clients require
+# approval before they can leave the network-disabled command sandbox.
+prompt_network_commands = [
     ["curl"],
     ["wget"],
     ["nc"],
@@ -54,15 +47,15 @@ forbidden_network_commands = [
     ["helm"],
 ]
 
-for command in forbidden_network_commands:
+for command in prompt_network_commands:
     prefix_rule(
         pattern = command,
-        decision = "forbidden",
-        justification = "Direct network and infrastructure clients are disabled; use an approved scoped tool instead.",
+        decision = "prompt",
+        justification = "This command can access remote systems and requires explicit approval.",
     )
 
-# Global package installation is forbidden.
-forbidden_install_commands = [
+# Package and system installation requires approval.
+prompt_install_commands = [
     ["npm", "install", "-g"],
     ["npm", "i", "-g"],
     ["pip", "install"],
@@ -74,14 +67,14 @@ forbidden_install_commands = [
     ["dnf", "install"],
 ]
 
-for command in forbidden_install_commands:
+for command in prompt_install_commands:
     prefix_rule(
         pattern = command,
-        decision = "forbidden",
-        justification = "Global package installation is disabled; use the project's declared dependency workflow.",
+        decision = "prompt",
+        justification = "Installing packages can execute third-party code and requires explicit approval.",
     )
 
-# Preserve the Claude policy's hard stops for the most dangerous rm/chmod forms.
+# Preserve hard stops for commands that target the filesystem root or home.
 forbidden_destructive_commands = [
     ["rm", "-rf", "/"],
     ["rm", "-fr", "/"],
@@ -91,7 +84,6 @@ forbidden_destructive_commands = [
     ["rm", "-fr", "~"],
     ["rm", "-rf", "~*"],
     ["rm", "-fr", "~*"],
-    ["chmod", "777"],
 ]
 
 for command in forbidden_destructive_commands:
@@ -111,6 +103,14 @@ prompt_commands = [
     ["git", "stash", "drop"],
     ["rm"],
     ["chmod"],
+    ["chown"],
+    ["dd"],
+    ["shred"],
+    ["launchctl"],
+    ["systemctl"],
+    ["service"],
+    ["crontab"],
+    ["at"],
     ["make", "deploy"],
     ["make", "release"],
     ["npm", "run", "deploy"],
@@ -139,4 +139,11 @@ prefix_rule(
     pattern = ["git", "fetch"],
     decision = "allow",
     justification = "Fetching remote refs is read-only and explicitly allowed by the global policy.",
+)
+
+# Preserve the previously approved project-scoped Context7 documentation helper.
+prefix_rule(
+    pattern = ["python3", "scripts/context7.py"],
+    decision = "allow",
+    justification = "The repository-scoped Context7 helper is explicitly approved.",
 )

--- a/home/dot_config/opencode/AGENTS.md.tmpl
+++ b/home/dot_config/opencode/AGENTS.md.tmpl
@@ -1,0 +1,95 @@
+# Global OpenCode Instructions
+
+Behavioral guidelines to reduce common LLM coding mistakes. These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## Refer to
+
+Refer to me as Ivan
+
+## General Principles
+
+- **Verify before fixing**: Confirm bug is triggerable by user before fixing. No fixes for theoretical issues in unreachable code paths.
+- **Understand before changing**: Understand why existing code works before modifying. No redesigning APIs, protocols, or data flows unless asked.
+- **Run and verify**: Run scripts/code after modifying to confirm they work. Prove correctness, don't assume.
+- **Keep it simple**: Prefer straightforward solutions. No defensive code (retries, timeouts, guards) without evidence problem exists. Less code is better.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. No AI Attribution
+
+**Never co-sign a commit or a PR.**
+
+- No `Co-Authored-By` trailer for any AI/assistant identity.
+- No "Generated with OpenCode", no 🤖 footer, no attribution line in PR bodies or descriptions.
+- Applies even when tooling defaults or harness instructions say otherwise.
+
+## Skills
+
+OpenCode discovers the canonical skills in `~/.agents/skills`. Load a relevant skill before doing its work.
+
+`.chezmoitemplates/ste-card.tmpl` is the single source of the card below. Change that one file,
+then use `chezmoi apply`.
+
+{{ includeTemplate "ste-card.tmpl" . }}
+
+## Commit Messages
+
+- `Conventional Commits` format. A subject of 50 characters at most, imperative mood, and no
+  period at the end.
+- Write a body only if the subject and the diff do not give the cause of the change.
+- The subject line is the one part that STE does not include. Write the commit body, the PR
+  title, and the PR body in STE.

--- a/home/dot_config/opencode/agents/ci-watcher.md.tmpl
+++ b/home/dot_config/opencode/agents/ci-watcher.md.tmpl
@@ -1,0 +1,1 @@
+{{- includeTemplate "agents/agent-opencode.tmpl" (dict "ctx" . "id" "ci-watcher" "body" (includeTemplate "agents/body/ci-watcher.md" .)) -}}

--- a/home/dot_config/opencode/agents/comment-sicko.md.tmpl
+++ b/home/dot_config/opencode/agents/comment-sicko.md.tmpl
@@ -1,0 +1,1 @@
+{{- includeTemplate "agents/agent-opencode.tmpl" (dict "ctx" . "id" "comment-sicko" "body" (includeTemplate "agents/body/comment-sicko.md" .)) -}}

--- a/home/dot_config/opencode/agents/prose-editor.md.tmpl
+++ b/home/dot_config/opencode/agents/prose-editor.md.tmpl
@@ -1,0 +1,1 @@
+{{- includeTemplate "agents/agent-opencode.tmpl" (dict "ctx" . "id" "prose-editor" "body" (includeTemplate "agents/body/prose-editor.md" .)) -}}

--- a/home/dot_config/opencode/agents/security-reviewer.md.tmpl
+++ b/home/dot_config/opencode/agents/security-reviewer.md.tmpl
@@ -1,0 +1,1 @@
+{{- includeTemplate "agents/agent-opencode.tmpl" (dict "ctx" . "id" "security-reviewer" "body" (includeTemplate "agents/body/security-reviewer.md" .)) -}}

--- a/home/dot_config/opencode/agents/skeptical-reviewer.md.tmpl
+++ b/home/dot_config/opencode/agents/skeptical-reviewer.md.tmpl
@@ -1,0 +1,1 @@
+{{- includeTemplate "agents/agent-opencode.tmpl" (dict "ctx" . "id" "skeptical-reviewer" "body" (includeTemplate "agents/body/skeptical-reviewer.md" .)) -}}

--- a/home/dot_config/opencode/agents/unit-test-writer.md.tmpl
+++ b/home/dot_config/opencode/agents/unit-test-writer.md.tmpl
@@ -1,0 +1,1 @@
+{{- includeTemplate "agents/agent-opencode.tmpl" (dict "ctx" . "id" "unit-test-writer" "body" (includeTemplate "agents/body/unit-test-writer.md" .)) -}}

--- a/home/dot_config/opencode/cli.json
+++ b/home/dot_config/opencode/cli.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://opencode.ai/v2/cli.json",
+  "attention": {
+    "enabled": true,
+    "notifications": true,
+    "sound": false
+  },
+  "diffs": {
+    "source": "branch",
+    "wrap": "word",
+    "tree": true,
+    "single": false,
+    "view": "auto"
+  },
+  "terminal": {
+    "title": true,
+    "copy": "select"
+  },
+  "theme": {
+    "name": "catppuccin-macchiato",
+    "mode": "system"
+  }
+}

--- a/home/dot_config/opencode/modify_opencode.jsonc
+++ b/home/dot_config/opencode/modify_opencode.jsonc
@@ -1,0 +1,301 @@
+#!/bin/sh
+set -eu
+
+# OpenCode can add provider and MCP settings to this file. Merge the managed
+# policy into that live state instead of replacing unrelated local settings.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required to merge the managed OpenCode configuration" >&2
+    exit 1
+fi
+
+current_file=$(mktemp "${TMPDIR:-/tmp}/opencode-current.XXXXXX")
+managed_file=$(mktemp "${TMPDIR:-/tmp}/opencode-managed.XXXXXX")
+trap 'rm -f "$current_file" "$managed_file"' EXIT HUP INT TERM
+
+cat >"$current_file"
+cat >"$managed_file" <<'EOF'
+{
+  "$schema": "https://opencode.ai/config.json",
+  "shell": "/bin/zsh",
+  "update": "notify",
+  "snapshots": true,
+  "lsp": true,
+  "watcher": {
+    "ignore": [
+      ".git/**",
+      "node_modules/**",
+      "dist/**",
+      "coverage/**"
+    ]
+  },
+  "plugins": ["./plugins/rtk","opencode-cursor-provider"],
+  "permissions": [
+    { "action": "external_directory", "resource": "~/.agents/skills/*", "effect": "allow" },
+    { "action": "shell", "resource": "git push --force *", "effect": "ask" },
+    { "action": "shell", "resource": "git push -f *", "effect": "ask" },
+    { "action": "shell", "resource": "gh pr merge *", "effect": "ask" },
+    { "action": "shell", "resource": "git rebase *", "effect": "ask" },
+    { "action": "shell", "resource": "git reset --hard *", "effect": "ask" },
+    { "action": "shell", "resource": "git clean -fd *", "effect": "ask" },
+    { "action": "shell", "resource": "git tag *", "effect": "ask" },
+    { "action": "shell", "resource": "git stash drop *", "effect": "ask" },
+    { "action": "shell", "resource": "chmod *", "effect": "ask" },
+    { "action": "shell", "resource": "make deploy *", "effect": "ask" },
+    { "action": "shell", "resource": "make release *", "effect": "ask" },
+    { "action": "shell", "resource": "npm run deploy *", "effect": "ask" },
+    { "action": "shell", "resource": "npm run release *", "effect": "ask" },
+    { "action": "shell", "resource": "docker rm *", "effect": "ask" },
+    { "action": "shell", "resource": "docker rmi *", "effect": "ask" },
+    { "action": "shell", "resource": "docker system prune *", "effect": "ask" },
+    { "action": "shell", "resource": "docker-compose down *", "effect": "ask" },
+    { "action": "shell", "resource": "psql *", "effect": "ask" },
+    { "action": "shell", "resource": "mysql *", "effect": "ask" },
+    { "action": "shell", "resource": "mongosh *", "effect": "ask" },
+    { "action": "shell", "resource": "redis-cli *", "effect": "ask" },
+    { "action": "shell", "resource": "sqlite3 *", "effect": "ask" },
+    { "action": "shell", "resource": "sudo *", "effect": "deny" },
+    { "action": "shell", "resource": "su *", "effect": "deny" },
+    { "action": "shell", "resource": "doas *", "effect": "deny" },
+    { "action": "shell", "resource": "pkexec *", "effect": "deny" },
+    { "action": "shell", "resource": "runas *", "effect": "deny" },
+    { "action": "shell", "resource": "rm -rf /", "effect": "deny" },
+    { "action": "shell", "resource": "rm -fr /", "effect": "deny" },
+    { "action": "shell", "resource": "rm -rf ~*", "effect": "deny" },
+    { "action": "shell", "resource": "rm -rf /Users*", "effect": "deny" },
+    { "action": "shell", "resource": "rm -fr /Users*", "effect": "deny" },
+    { "action": "shell", "resource": "rm -rf $HOME*", "effect": "deny" },
+    { "action": "shell", "resource": "rm -fr $HOME*", "effect": "deny" },
+    { "action": "shell", "resource": "rm -rf ${HOME}*", "effect": "deny" },
+    { "action": "shell", "resource": "rm -fr ${HOME}*", "effect": "deny" },
+    { "action": "shell", "resource": "rm -rf ..*", "effect": "deny" },
+    { "action": "shell", "resource": "rm -fr ..*", "effect": "deny" },
+    { "action": "shell", "resource": "rm -r ..*", "effect": "deny" },
+    { "action": "shell", "resource": "mkfs *", "effect": "deny" },
+    { "action": "shell", "resource": "diskutil eraseDisk *", "effect": "deny" },
+    { "action": "shell", "resource": "dd if=/dev/zero *", "effect": "deny" },
+    { "action": "shell", "resource": "shred *", "effect": "deny" },
+    { "action": "shell", "resource": "curl *", "effect": "deny" },
+    { "action": "shell", "resource": "wget *", "effect": "deny" },
+    { "action": "shell", "resource": "nc *", "effect": "deny" },
+    { "action": "shell", "resource": "ncat *", "effect": "deny" },
+    { "action": "shell", "resource": "netcat *", "effect": "deny" },
+    { "action": "shell", "resource": "ssh *", "effect": "deny" },
+    { "action": "shell", "resource": "scp *", "effect": "deny" },
+    { "action": "shell", "resource": "sftp *", "effect": "deny" },
+    { "action": "shell", "resource": "rsync *", "effect": "deny" },
+    { "action": "shell", "resource": "ngrok *", "effect": "deny" },
+    { "action": "shell", "resource": "cloudflared *", "effect": "deny" },
+    { "action": "shell", "resource": "aws *", "effect": "deny" },
+    { "action": "shell", "resource": "gcloud *", "effect": "deny" },
+    { "action": "shell", "resource": "az *", "effect": "deny" },
+    { "action": "shell", "resource": "gsutil *", "effect": "deny" },
+    { "action": "shell", "resource": "terraform *", "effect": "deny" },
+    { "action": "shell", "resource": "pulumi *", "effect": "deny" },
+    { "action": "shell", "resource": "kubectl *", "effect": "deny" },
+    { "action": "shell", "resource": "helm *", "effect": "deny" },
+    { "action": "read", "resource": "*.env", "effect": "deny" },
+    { "action": "read", "resource": "*.env.local", "effect": "deny" },
+    { "action": "read", "resource": "*.env.*.local", "effect": "deny" },
+    { "action": "read", "resource": "*.env.development", "effect": "deny" },
+    { "action": "read", "resource": "*.env.production", "effect": "deny" },
+    { "action": "read", "resource": "*.env.prod", "effect": "deny" },
+    { "action": "read", "resource": "*.env.staging", "effect": "deny" },
+    { "action": "read", "resource": "*.env.test", "effect": "deny" },
+    { "action": "read", "resource": "*.env.secret*", "effect": "deny" },
+    { "action": "read", "resource": "*.env.vault", "effect": "deny" },
+    { "action": "read", "resource": "*.envrc", "effect": "deny" },
+    { "action": "read", "resource": "*secrets/*", "effect": "deny" },
+    { "action": "read", "resource": "*.pem", "effect": "deny" },
+    { "action": "read", "resource": "*.key", "effect": "deny" },
+    { "action": "read", "resource": "*.p12", "effect": "deny" },
+    { "action": "read", "resource": "*.pfx", "effect": "deny" },
+    { "action": "read", "resource": "*.cer", "effect": "deny" },
+    { "action": "read", "resource": "*.crt", "effect": "deny" },
+    { "action": "read", "resource": "*id_rsa", "effect": "deny" },
+    { "action": "read", "resource": "*id_ed25519", "effect": "deny" },
+    { "action": "read", "resource": "*.ssh/*", "effect": "deny" },
+    { "action": "read", "resource": "*.aws/credentials", "effect": "deny" },
+    { "action": "read", "resource": "*.aws/config", "effect": "deny" },
+    { "action": "read", "resource": "*.config/gcloud/*", "effect": "deny" },
+    { "action": "read", "resource": "*.kube/config", "effect": "deny" },
+    { "action": "read", "resource": "*vault-token", "effect": "deny" },
+    { "action": "read", "resource": "*.netrc", "effect": "deny" },
+    { "action": "read", "resource": "*.npmrc", "effect": "deny" },
+    { "action": "read", "resource": "*.pypirc", "effect": "deny" },
+    { "action": "edit", "resource": "*.env", "effect": "deny" },
+    { "action": "edit", "resource": "*.env.local", "effect": "deny" },
+    { "action": "edit", "resource": "*.env.*.local", "effect": "deny" },
+    { "action": "edit", "resource": "*.env.development", "effect": "deny" },
+    { "action": "edit", "resource": "*.env.production", "effect": "deny" },
+    { "action": "edit", "resource": "*.env.prod", "effect": "deny" },
+    { "action": "edit", "resource": "*.env.staging", "effect": "deny" },
+    { "action": "edit", "resource": "*.env.test", "effect": "deny" },
+    { "action": "edit", "resource": "*.env.secret*", "effect": "deny" },
+    { "action": "edit", "resource": "*.env.vault", "effect": "deny" },
+    { "action": "edit", "resource": "*.envrc", "effect": "deny" },
+    { "action": "edit", "resource": "*secrets/*", "effect": "deny" },
+    { "action": "edit", "resource": "*.pem", "effect": "deny" },
+    { "action": "edit", "resource": "*.key", "effect": "deny" },
+    { "action": "edit", "resource": "*.p12", "effect": "deny" },
+    { "action": "edit", "resource": "*.pfx", "effect": "deny" },
+    { "action": "edit", "resource": "*.cer", "effect": "deny" },
+    { "action": "edit", "resource": "*.crt", "effect": "deny" },
+    { "action": "edit", "resource": "*id_rsa", "effect": "deny" },
+    { "action": "edit", "resource": "*id_ed25519", "effect": "deny" },
+    { "action": "edit", "resource": "*.ssh/*", "effect": "deny" },
+    { "action": "edit", "resource": "*.aws/credentials", "effect": "deny" },
+    { "action": "edit", "resource": "*.aws/config", "effect": "deny" },
+    { "action": "edit", "resource": "*.config/gcloud/*", "effect": "deny" },
+    { "action": "edit", "resource": "*.kube/config", "effect": "deny" },
+    { "action": "edit", "resource": "*vault-token", "effect": "deny" },
+    { "action": "edit", "resource": "*.netrc", "effect": "deny" },
+    { "action": "edit", "resource": "*.npmrc", "effect": "deny" },
+    { "action": "edit", "resource": "*.pypirc", "effect": "deny" },
+    { "action": "edit", "resource": "*.aws/*", "effect": "deny" },
+    { "action": "edit", "resource": "*.kube/*", "effect": "deny" },
+    { "action": "shell", "resource": "launchctl *", "effect": "deny" },
+    { "action": "shell", "resource": "systemctl *", "effect": "deny" },
+    { "action": "shell", "resource": "service *", "effect": "deny" },
+    { "action": "shell", "resource": "crontab *", "effect": "deny" },
+    { "action": "shell", "resource": "at *", "effect": "deny" },
+    { "action": "shell", "resource": "chown *", "effect": "deny" },
+    { "action": "shell", "resource": "chmod 777 *", "effect": "deny" },
+    { "action": "shell", "resource": "visudo *", "effect": "deny" },
+    { "action": "shell", "resource": "passwd *", "effect": "deny" },
+    { "action": "shell", "resource": "git push origin main *", "effect": "deny" },
+    { "action": "shell", "resource": "git push origin master *", "effect": "deny" },
+    { "action": "shell", "resource": "git push -u origin main *", "effect": "deny" },
+    { "action": "shell", "resource": "git push -u origin master *", "effect": "deny" },
+    { "action": "shell", "resource": "git push --set-upstream origin main *", "effect": "deny" },
+    { "action": "shell", "resource": "git push --set-upstream origin master *", "effect": "deny" },
+    { "action": "shell", "resource": "git push -f origin main *", "effect": "deny" },
+    { "action": "shell", "resource": "git push -f origin master *", "effect": "deny" },
+    { "action": "shell", "resource": "git push --force origin main *", "effect": "deny" },
+    { "action": "shell", "resource": "git push --force origin master *", "effect": "deny" },
+    { "action": "shell", "resource": "git push origin HEAD:main", "effect": "deny" },
+    { "action": "shell", "resource": "git push origin HEAD:master", "effect": "deny" },
+    { "action": "shell", "resource": "npm install -g *", "effect": "deny" },
+    { "action": "shell", "resource": "pip install *", "effect": "deny" },
+    { "action": "shell", "resource": "pip3 install *", "effect": "deny" },
+    { "action": "shell", "resource": "brew install *", "effect": "deny" },
+    { "action": "shell", "resource": "apt-get install *", "effect": "deny" },
+    { "action": "shell", "resource": "apt install *", "effect": "deny" },
+    { "action": "shell", "resource": "yum install *", "effect": "deny" },
+    { "action": "shell", "resource": "dnf install *", "effect": "deny" }
+  ]
+}
+EOF
+
+python3 - "$current_file" "$managed_file" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def parse_jsonc(text: str):
+    without_comments = []
+    index = 0
+    in_string = False
+    escaped = False
+
+    while index < len(text):
+        char = text[index]
+
+        if in_string:
+            without_comments.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+
+        if char == '"':
+            in_string = True
+            without_comments.append(char)
+            index += 1
+            continue
+
+        if text.startswith("//", index):
+            without_comments.extend("  ")
+            index += 2
+            while index < len(text) and text[index] not in "\r\n":
+                without_comments.append(" ")
+                index += 1
+            continue
+
+        if text.startswith("/*", index):
+            without_comments.extend("  ")
+            index += 2
+            while index < len(text) and not text.startswith("*/", index):
+                without_comments.append(text[index] if text[index] in "\r\n" else " ")
+                index += 1
+            if index == len(text):
+                raise ValueError("unterminated block comment")
+            without_comments.extend("  ")
+            index += 2
+            continue
+
+        without_comments.append(char)
+        index += 1
+
+    cleaned = "".join(without_comments)
+    without_trailing_commas = []
+    index = 0
+    in_string = False
+    escaped = False
+
+    while index < len(cleaned):
+        char = cleaned[index]
+
+        if in_string:
+            without_trailing_commas.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == ",":
+            lookahead = index + 1
+            while lookahead < len(cleaned) and cleaned[lookahead].isspace():
+                lookahead += 1
+            if lookahead < len(cleaned) and cleaned[lookahead] in "}]":
+                index += 1
+                continue
+
+        without_trailing_commas.append(char)
+        index += 1
+
+    return json.loads("".join(without_trailing_commas))
+
+
+current_path, managed_path = map(pathlib.Path, sys.argv[1:])
+current_text = current_path.read_text()
+
+try:
+    current = parse_jsonc(current_text) if current_text.strip() else {}
+    managed = json.loads(managed_path.read_text())
+except (json.JSONDecodeError, ValueError) as error:
+    raise SystemExit(f"cannot merge OpenCode config: {error}")
+
+if not isinstance(current, dict):
+    raise SystemExit("cannot merge OpenCode config: root must be an object")
+
+merged = current | managed
+
+if current == merged:
+    sys.stdout.write(current_text)
+    if current_text and not current_text.endswith("\n"):
+        sys.stdout.write("\n")
+else:
+    json.dump(merged, sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+PY

--- a/home/dot_config/opencode/package.json
+++ b/home/dot_config/opencode/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "@opencode-ai/plugin": "0.0.0-beta-19059"
+  }
+}

--- a/home/dot_config/opencode/plugins/rtk/index.ts
+++ b/home/dot_config/opencode/plugins/rtk/index.ts
@@ -1,0 +1,28 @@
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+import { Plugin } from "@opencode-ai/plugin"
+
+const execute = promisify(execFile)
+
+export default Plugin.define({
+  id: "rtk",
+  async setup(ctx) {
+    const registration = await ctx.tool.hook("execute.before", async (event) => {
+      if (event.tool !== "shell") return
+      if (typeof event.input !== "object" || event.input === null || !("command" in event.input)) return
+
+      const command = event.input.command
+      if (typeof command !== "string" || command.length === 0) return
+
+      try {
+        const { stdout } = await execute("rtk", ["rewrite", command], { encoding: "utf8" })
+        const rewritten = stdout.trim()
+        if (rewritten && rewritten !== command) event.input.command = rewritten
+      } catch {
+        return
+      }
+    })
+
+    return () => registration.dispose()
+  },
+})

--- a/home/dot_config/opencode/plugins/statusline/format.ts
+++ b/home/dot_config/opencode/plugins/statusline/format.ts
@@ -1,0 +1,120 @@
+// Pure formatting for the status line. No host imports so it runs in tests.
+// Colors are Catppuccin Macchiato, matched to the Claude status line.
+
+export const color = {
+  mauve: "#c6a0f6",
+  blue: "#8aadf4",
+  lavender: "#b7c0f7",
+  teal: "#8bd5ca",
+  green: "#a6da95",
+  yellow: "#eed49f",
+  peach: "#f5a97f",
+  red: "#ed8796",
+  pink: "#f58cae",
+  text: "#cad3f5",
+  overlay: "#6e738d",
+} as const
+
+export const FALLBACK_CONTEXT_LIMIT = 200_000
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min
+  return Math.min(Math.max(value, min), max)
+}
+
+export function truncate(value: string, max: number): string {
+  if (value.length <= max) return value
+  if (max <= 1) return "…"
+  return `${value.slice(0, max - 1)}…`
+}
+
+export type TokenUsage = {
+  input: number
+  cache?: { read: number; write: number }
+}
+
+// Current context fill. Prefer the last assistant turn. Fall back to session totals.
+export function contextUsed(tokens?: TokenUsage): number {
+  if (!tokens) return 0
+  return tokens.input + (tokens.cache?.read ?? 0) + (tokens.cache?.write ?? 0)
+}
+
+export function formatTokens(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "0"
+  if (n < 1000) return String(Math.round(n))
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`
+  return `${(n / 1_000_000).toFixed(1)}M`
+}
+
+export function formatCost(usd: number): string {
+  if (!Number.isFinite(usd) || usd <= 0.001) return ""
+  // Keep cents for normal costs; show an extra digit for tiny costs so they
+  // do not round to a misleading $0.00.
+  if (usd < 0.01) return `$${usd.toFixed(3)}`
+  return `$${usd.toFixed(2)}`
+}
+
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 5000) return ""
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  if (s < 3600) return `${Math.floor(s / 60)}m`
+  return `${Math.floor(s / 3600)}h${String(Math.floor((s % 3600) / 60)).padStart(2, "0")}m`
+}
+
+// Shorten a provider model name. Anthropic ids place the version before the
+// family (claude-3-5-sonnet) or after it (claude-sonnet-4-5), so detect each
+// part on its own.
+export function prettyModel(raw: string): string {
+  const id = raw.toLowerCase()
+  const family = /opus/.test(id) ? "Opus" : /sonnet/.test(id) ? "Sonnet" : /haiku/.test(id) ? "Haiku" : ""
+  if (!family) return raw
+
+  let version = ""
+  if (/4[-_.]5/.test(id)) version = " 4.5"
+  else if (/3[-_.]5/.test(id)) version = " 3.5"
+  else if (/(?:^|[^0-9])4(?:[^0-9]|$)/.test(id)) version = " 4"
+  else if (/(?:^|[^0-9])3(?:[^0-9]|$)/.test(id)) version = " 3"
+
+  return version ? family + version : raw
+}
+
+export type ContextBar = {
+  filled: string
+  empty: string
+  tone: string
+  bold: boolean
+}
+
+const PARTIAL = ["", "▏", "▎", "▍", "▌", "▋", "▊", "▉"]
+
+function toneFor(pct: number): string {
+  if (pct >= 90) return color.red
+  if (pct >= 75) return color.peach
+  if (pct >= 50) return color.yellow
+  return color.green
+}
+
+// Smooth 8-cell bar with eighth-block partials, about 1.5% resolution.
+export function contextBar(used: number, limit: number, width = 8): ContextBar {
+  const cap = limit > 0 ? limit : FALLBACK_CONTEXT_LIMIT
+  const pct = clamp(Math.floor((used / cap) * 100), 0, 100)
+
+  if (used >= cap || pct >= 95) {
+    return { filled: "█".repeat(width), empty: "", tone: color.red, bold: true }
+  }
+
+  const eighths = clamp(Math.round((pct * width * 8) / 100), 0, width * 8)
+  const full = Math.floor(eighths / 8)
+  const partial = eighths % 8
+  const filledCount = partial > 0 ? full + 1 : full
+  const filled = "█".repeat(full) + PARTIAL[partial]
+  const empty = "░".repeat(Math.max(0, width - filledCount))
+
+  return { filled, empty, tone: toneFor(pct), bold: pct >= 75 }
+}
+
+export function contextPercent(used: number, limit: number): number {
+  const cap = limit > 0 ? limit : FALLBACK_CONTEXT_LIMIT
+  return clamp(Math.floor((used / cap) * 100), 0, 100)
+}

--- a/home/dot_config/opencode/plugins/statusline/index.ts
+++ b/home/dot_config/opencode/plugins/statusline/index.ts
@@ -1,0 +1,8 @@
+// Server entry kept for plugin-discovery layout parity. The status line lives
+// in tui.tsx; nothing runs on the server.
+import { Plugin } from "@opencode-ai/plugin"
+
+export default Plugin.define({
+  id: "statusline",
+  setup() {},
+})

--- a/home/dot_config/opencode/plugins/statusline/tui.tsx
+++ b/home/dot_config/opencode/plugins/statusline/tui.tsx
@@ -1,0 +1,151 @@
+import { Plugin, usePlugin } from "@opencode-ai/plugin/tui"
+import { For, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import {
+  contextBar,
+  contextPercent,
+  contextUsed,
+  formatCost,
+  formatDuration,
+  formatTokens,
+  prettyModel,
+  truncate,
+  color,
+  FALLBACK_CONTEXT_LIMIT,
+} from "./format.ts"
+
+type Props = {
+  sessionID?: string
+  mode: "normal" | "shell"
+  showDetails: boolean
+}
+
+type Token = { text: string; fg: string; bold?: boolean }
+
+function basename(path: string): string {
+  const parts = path.split("/").filter(Boolean)
+  return parts[parts.length - 1] ?? ""
+}
+
+function StatusLine(props: Props) {
+  const ctx = usePlugin()
+  const location = ctx.location ?? ctx.data.location.default()
+
+  const [now, setNow] = createSignal(Date.now())
+  const timer = setInterval(() => setNow(Date.now()), 1000)
+  onCleanup(() => clearInterval(timer))
+
+  createEffect(() => {
+    const id = props.sessionID
+    if (id) {
+      void ctx.data.session.sync(id)
+      void ctx.data.session.message.sync(id)
+      void ctx.data.session.permission.sync(id)
+    }
+    void ctx.data.location.model.sync(location)
+    void ctx.data.location.vcs.sync(location)
+  })
+
+  const tokens = createMemo<Token[]>(() => {
+    void now()
+    const out: Token[] = []
+    const sep = () => {
+      if (out.length) out.push({ text: " │ ", fg: color.overlay })
+    }
+    const add = (...runs: Token[]) => {
+      const visible = runs.filter((run) => run.text.length > 0)
+      if (!visible.length) return
+      sep()
+      out.push(...visible)
+    }
+
+    const id = props.sessionID
+    const session = id ? ctx.data.session.get(id) : undefined
+
+    const running = id ? ctx.data.session.status(id) === "running" : false
+    out.push({ text: running ? "●" : "○", fg: running ? color.green : color.overlay, bold: running })
+
+    const modelRef = session?.model
+    const modelInfo = modelRef
+      ? (ctx.data.location.model.list(location) ?? []).find(
+          (m) => m.providerID === modelRef.providerID && m.id === modelRef.id,
+        )
+      : undefined
+
+    const label = modelRef ? prettyModel(modelInfo?.name || modelRef.id || "") : ""
+    if (label) add({ text: label, fg: color.mauve, bold: true })
+
+    if (session) {
+      const messages = ctx.data.session.message.list(session.id) ?? []
+      let used = 0
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i]
+        if (message.type === "assistant") {
+          const fill = contextUsed(message.tokens)
+          if (fill > 0) {
+            used = fill
+            break
+          }
+        }
+      }
+      if (used === 0) used = contextUsed(session.tokens)
+      const turns = messages.filter((m) => m.type === "user").length
+      const cap = modelInfo?.limit?.context ?? FALLBACK_CONTEXT_LIMIT
+
+      if (used > 0) {
+        const overLimit = used >= cap && cap > 0
+        const pct = contextPercent(used, cap)
+        const bar = contextBar(used, cap)
+        const runs: Token[] = [
+          { text: bar.filled, fg: bar.tone, bold: bar.bold },
+          { text: bar.empty, fg: color.overlay },
+          overLimit
+            ? { text: ` ${formatTokens(cap)}+`, fg: color.red, bold: true }
+            : { text: ` ${pct}%`, fg: color.text },
+        ]
+        if (props.showDetails) runs.push({ text: ` ${formatTokens(used)}`, fg: color.overlay })
+        add(...runs)
+      }
+
+      const cost = formatCost(session.cost ?? 0)
+      if (cost) add({ text: cost, fg: color.yellow })
+
+      if (props.showDetails && turns > 0) add({ text: `${turns}t`, fg: color.overlay })
+      const duration = formatDuration(now() - session.time.created)
+      if (duration) add({ text: duration, fg: color.overlay })
+
+      if (session.agent) add({ text: `⊕ ${truncate(session.agent, 16)}`, fg: color.teal })
+    }
+
+    if (id) {
+      const perms = ctx.data.session.permission.list(id)?.length ?? 0
+      if (perms > 0) add({ text: `⚠ ${perms} permission${perms > 1 ? "s" : ""}`, fg: color.peach, bold: true })
+
+      const subs = (ctx.data.session.list() ?? []).filter((s) => s.parentID === id).length
+      if (subs > 0) add({ text: `⊕ ${subs} sub`, fg: color.teal })
+    }
+
+    if (location?.directory) add({ text: truncate(basename(location.directory), 24), fg: color.lavender })
+    const branch = ctx.data.location.vcs.info(location)?.branch?.current
+    if (branch && branch !== "HEAD") add({ text: `⎇ ${truncate(branch, 24)}`, fg: color.blue })
+
+    return out
+  })
+
+  return (
+    <box flexDirection="row">
+      <For each={tokens()}>{(t) => <text fg={t.fg} bold={t.bold}>{t.text}</text>}</For>
+    </box>
+  )
+}
+
+export default Plugin.define({
+  id: "statusline",
+  setup(ctx) {
+    return ctx.ui.slot({
+      replace: "prompt.footer",
+      render: (input) => (
+        <StatusLine sessionID={input.sessionID} mode={input.mode} showDetails={input.showDetails} />
+      ),
+    })
+  },
+})

--- a/home/dot_config/opencode/plugins/worktrunk/index.ts
+++ b/home/dot_config/opencode/plugins/worktrunk/index.ts
@@ -1,0 +1,49 @@
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+import { Plugin } from "@opencode-ai/plugin"
+
+const execute = promisify(execFile)
+
+export default Plugin.define({
+  id: "worktrunk",
+  setup(ctx) {
+    const controller = new AbortController()
+    const directory = ctx.location.directory
+
+    const updateMarker = async (marker?: string) => {
+      const action = marker ? ["set", marker] : ["clear"]
+
+      try {
+        await execute("wt", ["config", "state", "marker", ...action], { cwd: directory })
+      } catch {
+        return
+      }
+    }
+
+    const watcher = (async () => {
+      for await (const event of ctx.event.subscribe({ signal: controller.signal })) {
+        if (event.location?.directory !== directory) continue
+
+        switch (event.type) {
+          case "session.status":
+            await updateMarker(event.data.status.type === "idle" ? "💬" : "🤖")
+            break
+          case "session.idle":
+            await updateMarker("💬")
+            break
+          case "session.deleted":
+            await updateMarker()
+            break
+        }
+      }
+    })().catch((error: unknown) => {
+      if (!controller.signal.aborted) console.error("Worktrunk activity tracking stopped", error)
+    })
+
+    return async () => {
+      controller.abort()
+      await watcher
+      await updateMarker()
+    }
+  },
+})


### PR DESCRIPTION
## TL;DR

The dotfiles did not manage global OpenCode V2, and Codex used a stricter permission policy than the supported coding tools.
Add the OpenCode setup, align the Codex policy, and remove broken Homebrew package references.

**Files to review (23, +900 / -61):**

| File | Why |
|---|---|
| `home/dot_config/opencode/modify_opencode.jsonc` *(start here)* | Merges the managed OpenCode policy with machine-local settings. |
| `home/dot_config/opencode/AGENTS.md.tmpl` | Supplies global OpenCode instructions. |
| `home/.chezmoitemplates/agents/agent-opencode.tmpl` | Maps portable agent metadata to OpenCode subagent files. |
| `home/dot_config/opencode/plugins/` | Adds shell rewriting, status line, and Worktrunk integrations. |
| `home/dot_codex/modify_private_config.toml` | Sets the revised Codex workspace and network policy. |
| `home/dot_codex/rules/default.rules` | Moves approved elevated actions from hard denial to confirmation. |
| `home/Brewfile.tmpl` | Qualifies Transmission and removes the disabled Alacritty cask. |

## Why

OpenCode V2 needs global instructions, preferences, permissions, and portable subagents under `~/.config/opencode`.
Machine-local providers and MCP servers must remain intact when chezmoi applies the managed policy.

The Codex policy blocked network access and common administration commands instead of requesting approval.
The revised rules keep catastrophic actions forbidden and require approval for elevated actions.

## How

The OpenCode modifier merges owned top-level keys into the live JSONC file.
It preserves unrelated provider, MCP server, and reference settings.

Shared agent data now generates OpenCode subagents from the existing portable agent bodies.
The dependency script uses mise to install the OpenCode plugin package when its package manifest changes.

Codex uses a trusted workspace profile with protected credentials and approval-gated network access.
Command rules deny catastrophic actions and prompt for package installation, remote access, and system administration.

The Brewfile selects the Transmission cask explicitly and stops requesting the disabled Alacritty cask.

## Reviewer notes

- **Managed keys:** Chezmoi owns the OpenCode schema, shell, update policy, snapshots, watcher, plugins, and permissions.
- **Local settings:** The modifier preserves unrelated top-level OpenCode keys.
- **Permission boundary:** Private key files and cloud credentials remain inaccessible.
- **Review focus:** Check the OpenCode permission order and the Codex workspace policy.

## Tests

- `./scripts/lint.sh`
- `git diff --check`
- `chezmoi apply --dry-run`
- Rendered dependency script with Bun available only through mise
- Homebrew metadata and bundle resolution checks
