### PR TITLE
Install go-task from homebrew core

### DIFF
--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -105,7 +105,9 @@ brew "diffnav" # core formula. The dlvhdr tap pins a bad checksum for v0.12.0.
 # DEVELOPMENT TOOLS #
 brew "chezmoi"
 brew "gh"
-brew "go-task/tap/go-task"
+# Task runner. The core formula, not go-task/tap/go-task: Homebrew 6 reads no
+# formula from an untrusted tap, and the tap adds nothing over core.
+brew "go-task"
 brew "golangci-lint"
 brew "lazygit"
 brew "lazydocker"


### PR DESCRIPTION
## Why

The macOS job fails on `main` after #27.

```
The following taps are not trusted: go-task/tap
Homebrew is currently ignoring formulae, casks and commands from these taps
because tap trust is required.
'go-task/tap/go-task' formula is unreadable:
  No available formula with the name "go-task/tap/go-task".
```

Homebrew 6 reads no formula from a tap that the trust list does not name. I
added the tapped name in #27 and missed that rule.

## The fix

`homebrew/core` carries the same project at 3.53.1, bottled, and it installs
the same `task` binary. The core formula needs no trust entry.

`.chezmoidata/homebrew.yaml` is the other route, and it is the one this
repository already uses for `hashicorp/tap` and `aws/tap`. That file asks the
reader to read a formula before trusting it, and it prefers a single formula
over a whole tap. The tap gives nothing that core does not, thus core is the
smaller change. Say the word for the trust entry instead.

## This does not turn the job green on its own

Three Brewfile entries failed in run 34552631141, and only `go-task` is mine.

`little-snitch` failed with a 404 on `LittleSnitch-6.4.1.dmg`. The vendor
removed that file while the runner held a stale cask. `homebrew-cask` now
carries 6.5, thus a fresh run reads the new URL. `transmission` failed in the
same run. Both installed in run 34006677836 on 2026-09-06, and both install
here now, so I read them as upstream drift and left them alone.

Watch the macOS job on this pull request. If `little-snitch` fails again, it
needs its own fix and its own issue.

## Verification

`scripts/lint.sh` passes.

`brew bundle check` on the new entry reports `Formula go-task needs to be
installed or updated`, which is a resolved name. The old entry reported `No
available formula with the name`.
