### PR TITLE
Fix the macOS build: transmission cask, stale metadata, and the runner image

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -24,7 +24,10 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-14 # M1 Mac
+    # Apple Silicon, and macOS 26 to match the machine that this repository
+    # sets up. Homebrew calls macOS 14 a Tier 3 configuration and builds no
+    # bottle for it, thus mise and rtk had no bottle and the build failed.
+    runs-on: macos-26
 
     steps:
       # Test the checked-out tree, not the pushed branch. A remote clone cannot

--- a/home/.chezmoiscripts/darwin/run_onchange_after_bootstrap.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_after_bootstrap.sh.tmpl
@@ -67,6 +67,12 @@ install_brew_packages() {
         return 0
     fi
 
+    # Update before the install, or brew reads stale metadata and asks a vendor
+    # for a version that the vendor deleted. A GitHub runner has an old
+    # homebrew/cask tap, thus brew tried to get Little Snitch 6.4.1 and got a
+    # 404. A failure here must not stop the script.
+    brew update || echo "brew update failed."
+
     # brew bundle fetches each package before it installs any of them, so one
     # bad checksum in one tap stops all of them. Record that and continue, or
     # a third-party tap can stop mise and each later step too. The script then
@@ -78,7 +84,6 @@ install_brew_packages() {
     fi
 
     # These steps only tidy up or report, so a failure must not stop the script.
-    brew update || echo "brew update failed."
     brew upgrade || echo "brew upgrade failed."
     brew autoremove || echo "brew autoremove failed."
     brew cleanup || echo "brew cleanup failed."

--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -30,7 +30,11 @@ cask "visual-studio-code"
 cask "clocker" # Menubar World Clock
 cask "notion"
 cask "netnewswire"
-cask "homebrew/cask/transmission"
+# BitTorrent client. The `args` keep this entry out of the batched `brew
+# install`: that batch sends the bare token, and `transmission` is the old name
+# of the formula transmission-cli, thus brew installs the formula and the cask
+# stays absent. Alone, the entry installs with `--cask`.
+cask "transmission", args: { adopt: true }
 {{- end }}
 
 


### PR DESCRIPTION
The macOS build failed at `brew bundle`. Three causes, each with its own fix. The build is green now.

## 1. transmission installed as a formula

Homebrew 6 `brew bundle` puts each entry in one batched `brew install` with the bare token and no `--cask` or `--formula` flag (`bundle/installer.rb`, `batch_install_homebrew!`). `transmission` is the old name of the core formula `transmission-cli`, thus the ambiguous token resolved to the formula. CI installed `transmission-cli`, the cask stayed absent, and `brew bundle check` failed the job.

The `homebrew/cask/` prefix gave no protection. `homebrew_batchable?` rewrites the entry to `CaskLoader.load(...).full_name`, which is `transmission`. The prefix hid the bug on a machine that has no `homebrew/cask` tap, because a missing tap makes the entry leave the batch. The CI runner has that tap.

**Fix:** `cask "transmission", args: { adopt: true }`. A non-empty `args` hash keeps the entry out of the batch, thus brew installs it with `--cask`. The state of the tap does not matter. `--adopt` is what the batch sends for each cask, and the single-entry path adds it too, so the behavior is the same.

```
cask "homebrew/cask/transmission"          => batchable=false  (only because the tap is absent locally)
cask "transmission"                        => batchable=true   <- the CI failure
cask "transmission", args: { adopt: true } => batchable=false  <- this change
```

Each other cask in the personal profile got a check against the core formula names, the aliases, and the renames. `transmission` is the one collision. `copilot-cli` is safe, because its formula is in `aws/tap` and needs the prefix.

## 2. Stale metadata gave a 404 for Little Snitch

obdev returned 404 for `LittleSnitch-6.4.1.dmg`. obdev deletes an old disk image, and the runner has an old `homebrew/cask` tap, thus brew asked for a version that no longer exists. The cask is at 6.5.

**Fix:** `brew update` now runs before `brew bundle`, not after it. The install reads current metadata. The tidy-up steps (`upgrade`, `autoremove`, `cleanup`, `doctor`, `list`) stay after it, and a failure of the update still does not stop the script.

## 3. macOS 14 gets no bottle

With current metadata, `mise` and `rtk` had no bottle for `arm64_sonoma`, and brew reported a Tier 3 configuration. Homebrew builds a Tier 1 bottle only for each new release, thus more formulae get this problem each week.

**Fix:** the build runs on `macos-26`, which is Tier 1 and matches the machine that this repository sets up.

## Verification

All checks pass. `shellcheck` passes on the rendered bootstrap script.

Note for each existing machine: an old `go-task/tap` tap breaks the apply, because brew refuses to load the untrusted cask that the tap holds and the core formula never installs. Clear it with `brew uninstall --cask go-task` and `brew untap go-task/tap`.