### PR TITLE
Integrate OpenCode worktrees with Worktrunk

### DIFF
--- a/home/dot_config/opencode/cli.json
+++ b/home/dot_config/opencode/cli.json
@@ -19,5 +19,8 @@
   "theme": {
     "name": "catppuccin-macchiato",
     "mode": "system"
+  },
+  "session": {
+    "sidebar": "auto"
   }
 }

--- a/home/dot_config/opencode/package.json
+++ b/home/dot_config/opencode/package.json
@@ -1,6 +1,11 @@
 {
   "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test plugins/statusline/*.test.ts plugins/worktrunk/*.test.ts"
+  },
   "dependencies": {
-    "@opencode-ai/plugin": "0.0.0-beta-19059"
+    "@opencode-ai/plugin": "0.0.0-beta-19151",
+    "zod": "4.1.8"
   }
 }

--- a/home/dot_config/opencode/plugins/statusline/format.test.ts
+++ b/home/dot_config/opencode/plugins/statusline/format.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { checkoutLabel, relativeCheckoutPath } from "./format.ts"
+
+describe("checkoutLabel", () => {
+  it("labels the canonical checkout as the project root", () => {
+    assert.deepEqual(checkoutLabel("/code/project", "/code/project"), {
+      kind: "root",
+      name: "project",
+    })
+  })
+
+  it("labels another project checkout as a worktree", () => {
+    assert.deepEqual(checkoutLabel("/code/worktrees/feature-a", "/code/project"), {
+      kind: "worktree",
+      name: "feature-a",
+    })
+  })
+
+  it("ignores trailing path separators", () => {
+    assert.deepEqual(checkoutLabel("/code/project/", "/code/project"), {
+      kind: "root",
+      name: "project",
+    })
+  })
+})
+
+describe("relativeCheckoutPath", () => {
+  it("shows the project root as a dot", () => {
+    assert.equal(relativeCheckoutPath("/code/project", "/code/project"), ".")
+  })
+
+  it("shows a nested worktree relative to the project root", () => {
+    assert.equal(
+      relativeCheckoutPath("/code/project/.worktrees/feature-a", "/code/project"),
+      ".worktrees/feature-a",
+    )
+  })
+
+  it("keeps an external worktree path absolute", () => {
+    assert.equal(relativeCheckoutPath("/tmp/feature-a", "/code/project"), "/tmp/feature-a")
+  })
+})

--- a/home/dot_config/opencode/plugins/statusline/format.ts
+++ b/home/dot_config/opencode/plugins/statusline/format.ts
@@ -17,6 +17,36 @@ export const color = {
 
 export const FALLBACK_CONTEXT_LIMIT = 200_000
 
+export type CheckoutLabel =
+  | { kind: "root"; name: string }
+  | { kind: "worktree"; name: string }
+
+function normalizedPath(path: string): string {
+  return path.replace(/\/+$/, "") || "/"
+}
+
+function basename(path: string): string {
+  const parts = normalizedPath(path).split("/").filter(Boolean)
+  return parts[parts.length - 1] ?? "/"
+}
+
+export function checkoutLabel(projectDirectory: string, canonicalDirectory: string): CheckoutLabel {
+  const project = normalizedPath(projectDirectory)
+  const canonical = normalizedPath(canonicalDirectory)
+  return {
+    kind: project === canonical ? "root" : "worktree",
+    name: basename(project),
+  }
+}
+
+export function relativeCheckoutPath(projectDirectory: string, canonicalDirectory: string): string {
+  const project = normalizedPath(projectDirectory)
+  const canonical = normalizedPath(canonicalDirectory)
+  if (project === canonical) return "."
+  const prefix = canonical === "/" ? "/" : `${canonical}/`
+  return project.startsWith(prefix) ? project.slice(prefix.length) : project
+}
+
 function clamp(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return min
   return Math.min(Math.max(value, min), max)

--- a/home/dot_config/opencode/plugins/statusline/tui.tsx
+++ b/home/dot_config/opencode/plugins/statusline/tui.tsx
@@ -1,6 +1,7 @@
 import { Plugin, usePlugin } from "@opencode-ai/plugin/tui"
-import { For, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { For, createEffect, createMemo, createResource, createSignal, onCleanup } from "solid-js"
 import {
+  checkoutLabel,
   contextBar,
   contextPercent,
   contextUsed,
@@ -8,6 +9,7 @@ import {
   formatDuration,
   formatTokens,
   prettyModel,
+  relativeCheckoutPath,
   truncate,
   color,
   FALLBACK_CONTEXT_LIMIT,
@@ -20,15 +22,22 @@ type Props = {
 }
 
 type Token = { text: string; fg: string; bold?: boolean }
-
-function basename(path: string): string {
-  const parts = path.split("/").filter(Boolean)
-  return parts[parts.length - 1] ?? ""
-}
+type SidebarRow = { label: string; value: string; fg: string; bold?: boolean }
 
 function StatusLine(props: Props) {
   const ctx = usePlugin()
   const location = ctx.location ?? ctx.data.location.default()
+  const [checkout] = createResource(
+    () => location,
+    async (current) => {
+      try {
+        const info = await ctx.client.location.get({ location: current })
+        return checkoutLabel(info.project.directory, info.project.canonical)
+      } catch {
+        return current.directory ? checkoutLabel(current.directory, current.directory) : undefined
+      }
+    },
+  )
 
   const [now, setNow] = createSignal(Date.now())
   const timer = setInterval(() => setNow(Date.now()), 1000)
@@ -124,7 +133,12 @@ function StatusLine(props: Props) {
       if (subs > 0) add({ text: `⊕ ${subs} sub`, fg: color.teal })
     }
 
-    if (location?.directory) add({ text: truncate(basename(location.directory), 24), fg: color.lavender })
+    const checkoutInfo = checkout()
+    if (checkoutInfo?.kind === "worktree") {
+      add({ text: `wt ${truncate(checkoutInfo.name, 24)}`, fg: color.pink, bold: true })
+    } else if (checkoutInfo) {
+      add({ text: truncate(checkoutInfo.name, 24), fg: color.lavender })
+    }
     const branch = ctx.data.location.vcs.info(location)?.branch?.current
     if (branch && branch !== "HEAD") add({ text: `⎇ ${truncate(branch, 24)}`, fg: color.blue })
 
@@ -138,14 +152,85 @@ function StatusLine(props: Props) {
   )
 }
 
+function CheckoutSidebar(props: { sessionID: string }) {
+  const ctx = usePlugin()
+  const location = createMemo(() =>
+    ctx.data.session.get(props.sessionID)?.location ?? ctx.location ?? ctx.data.location.default()
+  )
+  const [checkout] = createResource(
+    location,
+    async (current) => {
+      try {
+        const info = await ctx.client.location.get({ location: current })
+        return {
+          label: checkoutLabel(info.project.directory, info.project.canonical),
+          path: relativeCheckoutPath(info.project.directory, info.project.canonical),
+        }
+      } catch {
+        return {
+          label: checkoutLabel(current.directory, current.directory),
+          path: ".",
+        }
+      }
+    },
+  )
+
+  createEffect(() => {
+    void ctx.data.session.sync(props.sessionID)
+    void ctx.data.location.vcs.sync(location())
+  })
+
+  const rows = createMemo<SidebarRow[]>(() => {
+    const info = checkout()
+    if (!info) return []
+
+    const worktree = info.label.kind === "worktree"
+    const rows: SidebarRow[] = [{
+      label: worktree ? "worktree" : "checkout",
+      value: info.label.name,
+      fg: worktree ? color.pink : color.lavender,
+      bold: worktree,
+    }]
+    const branch = ctx.data.location.vcs.info(location())?.branch
+    if (branch?.current && branch.current !== "HEAD") {
+      rows.push({ label: "branch", value: branch.current, fg: color.blue })
+    }
+    if (branch?.default && branch.default !== branch.current) {
+      rows.push({ label: "base", value: branch.default, fg: color.teal })
+    }
+    rows.push({ label: "path", value: info.path, fg: color.overlay })
+    return rows
+  })
+
+  return (
+    <box flexDirection="column" paddingTop={1}>
+      <text fg={color.overlay} bold>CHECKOUT</text>
+      <For each={rows()}>{(row) => (
+        <box flexDirection="row">
+          <text fg={color.overlay}>{row.label.padEnd(9)}</text>
+          <text fg={row.fg} bold={row.bold}>{truncate(row.value, 28)}</text>
+        </box>
+      )}</For>
+    </box>
+  )
+}
+
 export default Plugin.define({
   id: "statusline",
   setup(ctx) {
-    return ctx.ui.slot({
+    const stopStatusLine = ctx.ui.slot({
       replace: "prompt.footer",
       render: (input) => (
         <StatusLine sessionID={input.sessionID} mode={input.mode} showDetails={input.showDetails} />
       ),
     })
+    const stopSidebar = ctx.ui.slot({
+      before: "sidebar.footer",
+      render: (input) => <CheckoutSidebar sessionID={input.sessionID} />,
+    })
+    return () => {
+      stopSidebar()
+      stopStatusLine()
+    }
   },
 })

--- a/home/dot_config/opencode/plugins/worktrunk/index.ts
+++ b/home/dot_config/opencode/plugins/worktrunk/index.ts
@@ -1,14 +1,135 @@
 import { execFile } from "node:child_process"
+import path from "node:path"
 import { promisify } from "node:util"
 import { Plugin } from "@opencode-ai/plugin"
+import { z } from "zod"
+import { findNamedWorktree } from "./navigation.ts"
+import { createArguments, isSafeToRemove, parseList, parseSwitch, removeArguments } from "./worktree.ts"
 
 const execute = promisify(execFile)
 
+async function runWorktrunk(args: string[], cwd: string, signal?: AbortSignal): Promise<string> {
+  const result = await execute("wt", args, { cwd, encoding: "utf8", signal })
+  return result.stdout
+}
+
 export default Plugin.define({
   id: "worktrunk",
-  setup(ctx) {
+  async setup(ctx) {
     const controller = new AbortController()
     const directory = ctx.location.directory
+    const worktreeParent = path.join(ctx.location.project.canonical, ".worktrees")
+
+    const registration = await ctx.worktree.transform((editor) => {
+      editor.add({
+        id: "worktrunk",
+        async create(input, context) {
+          const stdout = await runWorktrunk(createArguments({
+            sourceDirectory: input.sourceDirectory,
+            suggestedDirectory: input.directory,
+            branch: input.branch,
+          }), input.sourceDirectory, context.signal)
+          return { directory: parseSwitch(stdout) }
+        },
+        async list(sourceDirectory, context) {
+          const stdout = await runWorktrunk(
+            ["-C", sourceDirectory, "list", "--format=json"],
+            sourceDirectory,
+            context.signal,
+          )
+          return parseList(stdout)
+        },
+        async remove(input, context) {
+          await runWorktrunk(removeArguments(input), input.directory, context.signal)
+        },
+      })
+    })
+
+    const tools = await ctx.tool.transform((editor) => {
+      editor.namespace({
+        name: "worktree",
+        description: "Run independent agent work in isolated Worktrunk worktrees.",
+      })
+      editor.add({
+        name: "agent",
+        description: "Run an independent task in a new Worktrunk worktree and OpenCode session.",
+        options: { namespace: "worktree" },
+        input: z.object({
+          task: z.string().min(1),
+          name: z.string().min(1).optional(),
+          agent: z.string().min(1).default("build"),
+        }),
+        async execute(input, tool) {
+          const parent = await ctx.session.get({ sessionID: tool.sessionID })
+          const name = input.name ?? `opencode-${String(tool.id).slice(-8)}`
+          const worktree = await ctx.worktree.create({
+            location: { directory: parent.location.directory },
+            name,
+            directory: worktreeParent,
+          })
+          const child = await ctx.session.create({
+            title: `Worktree agent: ${name}`,
+            agent: input.agent,
+            model: parent.model,
+            location: { directory: worktree.directory },
+            metadata: { worktree: worktree.directory, parentSessionID: parent.id },
+          })
+
+          await ctx.session.prompt({ sessionID: child.id, text: input.task })
+          await ctx.session.wait({ sessionID: child.id })
+          const messages = await ctx.session.context({ sessionID: child.id })
+          const response = messages.toReversed().find((message) => message.type === "assistant")
+          const answer = response?.content
+            .filter((part) => part.type === "text")
+            .map((part) => part.text)
+            .join("\n") ?? "The isolated agent did not return text."
+
+          const inventory = await runWorktrunk(
+            ["-C", worktree.directory, "list", "--format=json"],
+            worktree.directory,
+          )
+          const removed = isSafeToRemove(inventory, worktree.directory)
+          if (removed) await ctx.worktree.remove({ directory: worktree.directory, force: false })
+
+          return {
+            content: [
+              answer,
+              "",
+              `Session: ${child.id}`,
+              removed ? "Worktree: removed because it was unchanged" : `Worktree: ${worktree.directory}`,
+            ].join("\n"),
+            metadata: {
+              sessionID: child.id,
+              worktree: worktree.directory,
+              removed,
+            },
+          }
+        },
+      })
+    })
+
+    const commands = await ctx.command.transform((editor) => {
+      editor.add({
+        name: "worktree",
+        description: "Move this session to an existing or new Worktrunk worktree.",
+        async execute({ sessionID, prompt }) {
+          const name = prompt.text.trim()
+          if (!name) throw new Error("Use /worktree <name>")
+
+          const session = await ctx.session.get({ sessionID })
+          const location = { directory: session.location.directory }
+          const inventory = await ctx.worktree.list({ location })
+          const existing = findNamedWorktree(inventory, name)
+          const directory = existing ?? (await ctx.worktree.create({
+            location,
+            name,
+            directory: worktreeParent,
+          })).directory
+          await ctx.session.move({ sessionID, directory })
+          await ctx.session.synthetic({ sessionID, text: `Session moved to Worktrunk worktree ${name}.` })
+        },
+      })
+    })
 
     const updateMarker = async (marker?: string) => {
       const action = marker ? ["set", marker] : ["clear"]
@@ -44,6 +165,9 @@ export default Plugin.define({
       controller.abort()
       await watcher
       await updateMarker()
+      await commands.dispose()
+      await tools.dispose()
+      await registration.dispose()
     }
   },
 })

--- a/home/dot_config/opencode/plugins/worktrunk/navigation.test.ts
+++ b/home/dot_config/opencode/plugins/worktrunk/navigation.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { findNamedWorktree } from "./navigation.ts"
+
+describe("findNamedWorktree", () => {
+  it("finds a Worktrunk worktree by its directory name", () => {
+    assert.equal(findNamedWorktree([
+      { directory: "/repo", strategy: undefined },
+      { directory: "/repo/.worktrees/feature-a", strategy: "worktrunk" },
+    ], "feature-a"), "/repo/.worktrees/feature-a")
+  })
+
+  it("does not select the project root", () => {
+    assert.equal(findNamedWorktree([
+      { directory: "/repo", strategy: undefined },
+    ], "repo"), undefined)
+  })
+})

--- a/home/dot_config/opencode/plugins/worktrunk/navigation.ts
+++ b/home/dot_config/opencode/plugins/worktrunk/navigation.ts
@@ -1,0 +1,15 @@
+import path from "node:path"
+
+type WorktreeDirectory = {
+  readonly directory: string
+  readonly strategy?: string
+}
+
+export function findNamedWorktree(
+  inventory: readonly WorktreeDirectory[],
+  name: string,
+): string | undefined {
+  return inventory.find((item) =>
+    item.strategy === "worktrunk" && path.basename(path.normalize(item.directory)) === name
+  )?.directory
+}

--- a/home/dot_config/opencode/plugins/worktrunk/worktree.test.ts
+++ b/home/dot_config/opencode/plugins/worktrunk/worktree.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+  createArguments,
+  isSafeToRemove,
+  parseList,
+  parseSwitch,
+  removeArguments,
+} from "./worktree.ts"
+
+describe("Worktrunk worktree adapter", () => {
+  it("maps Worktrunk inventory to OpenCode entries", () => {
+    const output = JSON.stringify({
+      schema: 2,
+      items: [
+        { worktree: { path: "/repo", main: true } },
+        { worktree: { path: "/repo/.worktrees/feature-a", main: false } },
+        { branch: "without-worktree" },
+      ],
+    })
+
+    assert.deepEqual(parseList(output), [
+      { directory: "/repo", type: "root" },
+      { directory: "/repo/.worktrees/feature-a", type: "worktree" },
+    ])
+  })
+
+  it("reads the path returned by Worktrunk switch", () => {
+    assert.equal(
+      parseSwitch('{"action":"created","branch":"feature-a","path":"/repo/.worktrees/feature-a"}'),
+      "/repo/.worktrees/feature-a",
+    )
+  })
+
+  it("creates a branch through Worktrunk with hooks enabled", () => {
+    assert.deepEqual(createArguments({
+      sourceDirectory: "/repo",
+      suggestedDirectory: "/opencode/worktrees/feature-a",
+      branch: "origin/main",
+    }), [
+      "-C", "/repo", "--config-set", 'worktree-path="/opencode/worktrees/feature-a"',
+      "switch", "--create", "feature-a", "--base", "origin/main",
+      "--format=json", "--no-cd",
+    ])
+  })
+
+  it("starts from the active checkout when OpenCode does not supply a ref", () => {
+    assert.deepEqual(createArguments({
+      sourceDirectory: "/repo/.worktrees/current",
+      suggestedDirectory: "/opencode/worktrees/feature-b",
+    }), [
+      "-C", "/repo/.worktrees/current", "--config-set", 'worktree-path="/opencode/worktrees/feature-b"',
+      "switch", "--create", "feature-b", "--base", "@", "--format=json", "--no-cd",
+    ])
+  })
+
+  it("removes a worktree through Worktrunk without deleting unmerged work", () => {
+    assert.deepEqual(removeArguments({ directory: "/repo/.worktrees/feature-a", force: false }), [
+      "-C", "/repo/.worktrees/feature-a", "remove", "/repo/.worktrees/feature-a",
+      "--foreground", "--reap", "--format=json",
+    ])
+  })
+
+  it("passes only worktree force when OpenCode confirms data loss", () => {
+    assert.deepEqual(removeArguments({ directory: "/repo/.worktrees/feature-a", force: true }), [
+      "-C", "/repo/.worktrees/feature-a", "remove", "/repo/.worktrees/feature-a",
+      "--foreground", "--reap", "--format=json", "--force",
+    ])
+  })
+
+  it("allows automatic removal only for clean integrated worktrees", () => {
+    const output = JSON.stringify({
+      schema: 2,
+      items: [{
+        worktree: {
+          path: "/repo/.worktrees/feature-a",
+          main: false,
+          changes: {
+            staged: false,
+            modified: false,
+            untracked: false,
+            renamed: false,
+            deleted: false,
+            conflicted: false,
+          },
+        },
+        display: { state: "integrated" },
+      }],
+    })
+
+    assert.equal(isSafeToRemove(output, "/repo/.worktrees/feature-a"), true)
+  })
+
+  it("keeps worktrees with changes or unmerged commits", () => {
+    const dirty = JSON.stringify({
+      schema: 2,
+      items: [{
+        worktree: {
+          path: "/repo/.worktrees/feature-a",
+          main: false,
+          changes: { modified: true },
+        },
+        display: { state: "same_commit" },
+      }],
+    })
+    const ahead = JSON.stringify({
+      schema: 2,
+      items: [{
+        worktree: {
+          path: "/repo/.worktrees/feature-a",
+          main: false,
+          changes: {},
+        },
+        display: { state: "ahead" },
+      }],
+    })
+
+    assert.equal(isSafeToRemove(dirty, "/repo/.worktrees/feature-a"), false)
+    assert.equal(isSafeToRemove(ahead, "/repo/.worktrees/feature-a"), false)
+  })
+})

--- a/home/dot_config/opencode/plugins/worktrunk/worktree.ts
+++ b/home/dot_config/opencode/plugins/worktrunk/worktree.ts
@@ -1,0 +1,106 @@
+import path from "node:path"
+
+export type WorktreeEntry = {
+  readonly directory: string
+  readonly type: "root" | "worktree"
+}
+
+type CreateInput = {
+  readonly sourceDirectory: string
+  readonly suggestedDirectory: string
+  readonly branch?: string
+}
+
+type RemoveInput = {
+  readonly directory: string
+  readonly force: boolean
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseJson(output: string): unknown {
+  return JSON.parse(output)
+}
+
+export function parseList(output: string): WorktreeEntry[] {
+  const envelope = parseJson(output)
+  if (!record(envelope) || envelope.schema !== 2 || !Array.isArray(envelope.items)) {
+    throw new Error("Worktrunk returned an unsupported worktree list")
+  }
+
+  const entries: WorktreeEntry[] = []
+  for (const item of envelope.items) {
+    if (!record(item) || !record(item.worktree)) continue
+    const worktree = item.worktree
+    if (typeof worktree.path !== "string" || typeof worktree.main !== "boolean") {
+      throw new Error("Worktrunk returned an invalid worktree entry")
+    }
+    entries.push({
+      directory: worktree.path,
+      type: worktree.main ? "root" : "worktree",
+    })
+  }
+  return entries
+}
+
+export function parseSwitch(output: string): string {
+  const result = parseJson(output)
+  if (!record(result) || typeof result.path !== "string" || !result.path) {
+    throw new Error("Worktrunk did not return a worktree path")
+  }
+  return result.path
+}
+
+export function createArguments(input: CreateInput): string[] {
+  const name = path.basename(path.normalize(input.suggestedDirectory))
+  if (!name || name === "." || name === path.parse(input.suggestedDirectory).root) {
+    throw new Error("OpenCode did not supply a worktree name")
+  }
+
+  const args = [
+    "-C",
+    input.sourceDirectory,
+    "--config-set",
+    `worktree-path=${JSON.stringify(input.suggestedDirectory)}`,
+    "switch",
+    "--create",
+    name,
+  ]
+  args.push("--base", input.branch ?? "@")
+  args.push("--format=json", "--no-cd")
+  return args
+}
+
+export function isSafeToRemove(output: string, directory: string): boolean {
+  const envelope = parseJson(output)
+  if (!record(envelope) || envelope.schema !== 2 || !Array.isArray(envelope.items)) return false
+
+  const target = path.normalize(directory)
+  for (const item of envelope.items) {
+    if (!record(item) || !record(item.worktree)) continue
+    const worktree = item.worktree
+    if (typeof worktree.path !== "string" || path.normalize(worktree.path) !== target) continue
+    if (!record(worktree.changes) || !record(item.display)) return false
+    const changes = worktree.changes
+    const dirty = ["staged", "modified", "untracked", "renamed", "deleted", "conflicted"]
+      .some((key) => changes[key] === true)
+    return !dirty && (item.display.state === "empty" || item.display.state === "integrated")
+  }
+  return false
+}
+
+export function removeArguments(input: RemoveInput): string[] {
+  const args = [
+    "-C",
+    input.directory,
+    "remove",
+    input.directory,
+    "--foreground",
+    "--reap",
+    "--format=json",
+  ]
+  if (input.force) args.push("--force")
+  return args
+}

--- a/home/dot_config/worktrunk/config.toml
+++ b/home/dot_config/worktrunk/config.toml
@@ -3,6 +3,9 @@
 # Worktrees stay in the repository. The global gitignore holds `.worktrees/`.
 worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
 
+[pre-start]
+copy-ignored = "wt step copy-ignored --require-include"
+
 [list]
 # Pin the JSON output schema. A future release changes the default to 2.
 json-schema = 2

--- a/home/dot_config/zsh/autoload/functions.zsh
+++ b/home/dot_config/zsh/autoload/functions.zsh
@@ -8,6 +8,10 @@ function yy() {
 	rm -f -- "$tmp"
 }
 
+function opencode2() {
+	"$HOME/.local/bin/opencode2" "$@"
+}
+
 function kexec() {
   local choice=$(kubectl get pods -o custom-columns=NAME:.metadata.name --no-headers=true | fzf)
   kubectl exec -it $choice -- sh

--- a/home/dot_local/bin/executable_opencode2
+++ b/home/dot_local/bin/executable_opencode2
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+real_opencode2=$(mise which opencode2)
+if [[ ! -x "${real_opencode2}" ]]; then
+    echo "Mise did not return the OpenCode 2 executable" >&2
+    exit 127
+fi
+worktree_requested=false
+for argument in "$@"; do
+    case "${argument}" in
+        -w|--worktree|--worktree=*) worktree_requested=true ;;
+    esac
+done
+
+if [[ "${worktree_requested}" == false ]]; then
+    exec "${real_opencode2}" "$@"
+fi
+
+worktree_name=""
+session_id=""
+source_directory="${PWD}"
+source_found=false
+declare -a forwarded=()
+
+while (($#)); do
+    case "$1" in
+        -w|--worktree)
+            if (($# > 1)) && [[ "$2" != -* ]]; then
+                worktree_name=$2
+                shift
+            fi
+            ;;
+        --worktree=*)
+            worktree_name=${1#*=}
+            ;;
+        --server|--prompt|--log-level)
+            forwarded+=("$1")
+            option=$1
+            shift
+            if (($# == 0)); then
+                echo "${option} needs a value" >&2
+                exit 2
+            fi
+            forwarded+=("$1")
+            ;;
+        --session|-s)
+            forwarded+=("$1")
+            option=$1
+            shift
+            if (($# == 0)); then
+                echo "${option} needs a value" >&2
+                exit 2
+            fi
+            session_id=$1
+            forwarded+=("$1")
+            ;;
+        --session=*)
+            session_id=${1#*=}
+            if [[ -z "${session_id}" ]]; then
+                echo "--session needs a value" >&2
+                exit 2
+            fi
+            forwarded+=("$1")
+            ;;
+        *)
+            if [[ "$1" != -* && -d "$1" && "${source_found}" == false ]]; then
+                source_directory=$(cd "$1" && pwd -P)
+                source_found=true
+            else
+                forwarded+=("$1")
+            fi
+            ;;
+    esac
+    shift
+done
+
+location="location[directory]=${source_directory}"
+inventory=$("${real_opencode2}" api v2.worktree.list --param "${location}")
+worktree_directory=""
+worktree_created=false
+
+if [[ -n "${session_id}" ]]; then
+    session=$("${real_opencode2}" api v2.session.get --param "sessionID=${session_id}")
+    session_directory=$(python3 -c '
+import json
+import sys
+
+directory = json.load(sys.stdin).get("data", {}).get("location", {}).get("directory")
+if not isinstance(directory, str) or not directory:
+    raise SystemExit("OpenCode did not return the session directory")
+print(directory)
+' <<<"${session}")
+    session_worktree=$(python3 -c '
+import json
+import os
+import sys
+
+directory = os.path.normpath(sys.argv[1])
+for item in json.load(sys.stdin):
+    root = os.path.normpath(item["directory"])
+    if item.get("strategy") == "worktrunk" and os.path.commonpath([directory, root]) == root:
+        print(root)
+        break
+' "${session_directory}" <<<"${inventory}")
+
+    if [[ -z "${session_worktree}" ]]; then
+        if [[ -d "${session_directory}" ]]; then
+            echo "Session ${session_id} does not belong to a managed worktree" >&2
+        else
+            echo "The worktree for session ${session_id} no longer exists: ${session_directory}" >&2
+        fi
+        exit 2
+    fi
+
+    session_worktree_name=$(basename "${session_worktree}")
+    if [[ -n "${worktree_name}" && "${worktree_name}" != "${session_worktree_name}" ]]; then
+        echo "Session ${session_id} belongs to worktree ${session_worktree_name}, not ${worktree_name}" >&2
+        exit 2
+    fi
+    worktree_directory=${session_directory}
+elif [[ -n "${worktree_name}" ]]; then
+    worktree_directory=$(python3 -c '
+import json
+import os
+import sys
+
+name = sys.argv[1]
+for item in json.load(sys.stdin):
+    directory = item["directory"]
+    if item.get("strategy") == "worktrunk" and os.path.basename(os.path.normpath(directory)) == name:
+        print(directory)
+        break
+' "${worktree_name}" <<<"${inventory}")
+fi
+
+if [[ -z "${worktree_directory}" ]]; then
+    worktree_parent=$(wt -C "${source_directory}" step eval '{{ repo_path }}/.worktrees')
+    request=$(python3 -c '
+import json
+import sys
+
+request = {"directory": sys.argv[2]}
+if sys.argv[1]:
+    request["name"] = sys.argv[1]
+print(json.dumps(request, separators=(",", ":")))
+' "${worktree_name}" "${worktree_parent}")
+    created=$("${real_opencode2}" api v2.worktree.create --param "${location}" --data "${request}")
+    worktree_directory=$(python3 -c '
+import json
+import sys
+
+directory = json.load(sys.stdin).get("directory")
+if not isinstance(directory, str) or not directory:
+    raise SystemExit("OpenCode did not return a worktree directory")
+print(directory)
+' <<<"${created}")
+    worktree_created=true
+fi
+
+if [[ "${worktree_created}" == false ]]; then
+    if ((${#forwarded[@]})); then
+        exec "${real_opencode2}" "${forwarded[@]}" "${worktree_directory}"
+    fi
+    exec "${real_opencode2}" "${worktree_directory}"
+fi
+
+status=0
+if ((${#forwarded[@]})); then
+    "${real_opencode2}" "${forwarded[@]}" "${worktree_directory}" || status=$?
+else
+    "${real_opencode2}" "${worktree_directory}" || status=$?
+fi
+
+if worktree_state=$(wt -C "${worktree_directory}" list --format=json 2>/dev/null) && python3 -c '
+import json
+import os
+import sys
+
+target = os.path.normpath(sys.argv[1])
+for item in json.load(sys.stdin).get("items", []):
+    worktree = item.get("worktree") or {}
+    if os.path.normpath(worktree.get("path", "")) != target:
+        continue
+    changes = worktree.get("changes") or {}
+    clean = not any(changes.get(key, False) for key in (
+        "staged", "modified", "untracked", "renamed", "deleted", "conflicted"
+    ))
+    safe = (item.get("display") or {}).get("state") in ("empty", "integrated")
+    raise SystemExit(0 if clean and safe else 1)
+raise SystemExit(1)
+' "${worktree_directory}" <<<"${worktree_state}"
+then
+    request=$(python3 -c '
+import json
+import sys
+
+print(json.dumps({"directory": sys.argv[1], "force": False}, separators=(",", ":")))
+' "${worktree_directory}")
+    if ! "${real_opencode2}" api v2.worktree.remove --param "${location}" --data "${request}" >/dev/null; then
+        echo "Worktrunk could not remove the unchanged worktree: ${worktree_directory}" >&2
+    fi
+fi
+
+exit "${status}"

--- a/tests/opencode2-worktree.bats
+++ b/tests/opencode2-worktree.bats
@@ -1,0 +1,197 @@
+#!/usr/bin/env bats
+
+setup() {
+    export TEST_ROOT="${BATS_TEST_TMPDIR}/opencode2-worktree"
+    export TEST_BIN="${TEST_ROOT}/bin"
+    export TEST_LOG="${TEST_ROOT}/calls"
+    export LAUNCHER="${BATS_TEST_DIRNAME}/../home/dot_local/bin/executable_opencode2"
+    mkdir -p "${TEST_BIN}" "${TEST_ROOT}/repo"
+    REPO_REAL=$(cd "${TEST_ROOT}/repo" && pwd -P)
+
+    cat >"${TEST_BIN}/opencode2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\t' "$@" >>"${TEST_LOG}"
+printf '\n' >>"${TEST_LOG}"
+
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "v2.worktree.list" ]; then
+    printf '%s\n' "${LIST_RESPONSE:-[]}"
+elif [ "${1:-}" = "api" ] && [ "${2:-}" = "v2.worktree.create" ]; then
+    printf '%s\n' "${CREATE_RESPONSE}"
+elif [ "${1:-}" = "api" ] && [ "${2:-}" = "v2.worktree.remove" ]; then
+    printf '%s\n' '{}'
+elif [ "${1:-}" = "api" ] && [ "${2:-}" = "v2.session.get" ]; then
+    printf '%s\n' "${SESSION_RESPONSE}"
+fi
+EOF
+    chmod +x "${TEST_BIN}/opencode2"
+    cat >"${TEST_BIN}/mise" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${TEST_BIN}/opencode2"
+EOF
+    chmod +x "${TEST_BIN}/mise"
+cat >"${TEST_BIN}/wt" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"step eval"* ]]; then
+    printf '%s\n' "${WORKTREE_PARENT}"
+elif [[ -n "${WT_LIST_RESPONSE:-}" ]]; then
+    printf '%s\n' "${WT_LIST_RESPONSE}"
+else
+    printf '%s\n' '{"schema":2,"items":[]}'
+fi
+EOF
+    chmod +x "${TEST_BIN}/wt"
+    export WORKTREE_PARENT="${REPO_REAL}/.worktrees"
+    export PATH="${TEST_BIN}:${PATH}"
+}
+
+@test "passes arguments through when worktree mode is absent" {
+    run bash "${LAUNCHER}" --standalone "${TEST_ROOT}/repo"
+
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${TEST_LOG}")" = $'--standalone\t'"${TEST_ROOT}"$'/repo\t' ]
+}
+
+@test "preserves native session resume outside worktree mode" {
+    run bash "${LAUNCHER}" -s ses_test
+
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${TEST_LOG}")" = $'-s\tses_test\t' ]
+}
+
+@test "reuses an existing named worktree" {
+    export LIST_RESPONSE='[{"directory":"'"${TEST_ROOT}"'/trees/feature-a","strategy":"worktrunk"}]'
+
+    run bash "${LAUNCHER}" -w feature-a
+
+    [ "${status}" -eq 0 ]
+    [ "$(tail -n 1 "${TEST_LOG}")" = "${TEST_ROOT}/trees/feature-a"$'\t' ]
+    [ "$(grep -c 'v2.worktree.create' "${TEST_LOG}" || true)" -eq 0 ]
+}
+
+@test "does not reuse a worktree from another strategy" {
+    export LIST_RESPONSE='[{"directory":"'"${TEST_ROOT}"'/trees/feature-a","strategy":"git"}]'
+    export CREATE_RESPONSE='{"directory":"'"${TEST_ROOT}"'/trees/worktrunk-feature-a"}'
+
+    run bash "${LAUNCHER}" -w feature-a
+
+    [ "${status}" -eq 0 ]
+    grep -F $'api\tv2.worktree.create\t' "${TEST_LOG}"
+}
+
+@test "creates a missing named worktree" {
+    export CREATE_RESPONSE='{"directory":"'"${TEST_ROOT}"'/trees/feature-b"}'
+
+    run bash "${LAUNCHER}" --worktree feature-b
+
+    [ "${status}" -eq 0 ]
+    grep -F $'api\tv2.worktree.create\t' "${TEST_LOG}"
+    grep -F -- $'--data\t{"directory":"'"${WORKTREE_PARENT}"$'","name":"feature-b"}\t' "${TEST_LOG}"
+    [ "$(tail -n 1 "${TEST_LOG}")" = "${TEST_ROOT}/trees/feature-b"$'\t' ]
+}
+
+@test "lets OpenCode generate an unnamed worktree" {
+    export CREATE_RESPONSE='{"directory":"'"${TEST_ROOT}"'/trees/generated"}'
+
+    run bash "${LAUNCHER}" --worktree --standalone
+
+    [ "${status}" -eq 0 ]
+    grep -F -- $'--data\t{"directory":"'"${WORKTREE_PARENT}"$'"}\t' "${TEST_LOG}"
+    [ "$(tail -n 1 "${TEST_LOG}")" = $'--standalone\t'"${TEST_ROOT}"$'/trees/generated\t' ]
+}
+
+@test "removes a new unchanged worktree after OpenCode exits" {
+    local worktree="${TEST_ROOT}/trees/clean-tree"
+    export CREATE_RESPONSE='{"directory":"'"${worktree}"'"}'
+    export WT_LIST_RESPONSE='{"schema":2,"items":[{"worktree":{"path":"'"${worktree}"'","changes":{"staged":false,"modified":false,"untracked":false,"renamed":false,"deleted":false,"conflicted":false}},"display":{"state":"empty"}}]}'
+
+    run bash "${LAUNCHER}" --worktree clean-tree
+
+    [ "${status}" -eq 0 ]
+    grep -F $'api\tv2.worktree.remove\t' "${TEST_LOG}"
+    grep -F -- $'--data\t' "${TEST_LOG}" | grep -F '"force":false'
+}
+
+@test "keeps a new worktree with uncommitted changes" {
+    local worktree="${TEST_ROOT}/trees/dirty-tree"
+    export CREATE_RESPONSE='{"directory":"'"${worktree}"'"}'
+    export WT_LIST_RESPONSE='{"schema":2,"items":[{"worktree":{"path":"'"${worktree}"'","changes":{"staged":false,"modified":true,"untracked":false,"renamed":false,"deleted":false,"conflicted":false}},"display":{"state":"same_commit"}}]}'
+
+    run bash "${LAUNCHER}" --worktree dirty-tree
+
+    [ "${status}" -eq 0 ]
+    [ "$(grep -c 'v2.worktree.remove' "${TEST_LOG}" || true)" -eq 0 ]
+}
+
+@test "uses and replaces an explicit source directory" {
+    export CREATE_RESPONSE='{"directory":"'"${TEST_ROOT}"'/trees/feature-c"}'
+
+    run bash "${LAUNCHER}" "${TEST_ROOT}/repo" -w feature-c --auto
+
+    [ "${status}" -eq 0 ]
+    grep -F -- $'--param\tlocation[directory]='"${REPO_REAL}"$'\t' "${TEST_LOG}"
+    [ "$(tail -n 1 "${TEST_LOG}")" = $'--auto\t'"${TEST_ROOT}"$'/trees/feature-c\t' ]
+}
+
+@test "resumes a session in its existing worktree" {
+    local worktree="${TEST_ROOT}/trees/session-tree"
+    export LIST_RESPONSE='[{"directory":"'"${worktree}"'","strategy":"worktrunk"},{"directory":"'"${REPO_REAL}"'"}]'
+    export SESSION_RESPONSE='{"data":{"id":"ses_test","location":{"directory":"'"${worktree}"'"}}}'
+
+    run bash "${LAUNCHER}" "${TEST_ROOT}/repo" -w -s ses_test
+
+    [ "${status}" -eq 0 ]
+    grep -F $'api\tv2.session.get\t--param\tsessionID=ses_test\t' "${TEST_LOG}"
+    [ "$(grep -c 'v2.worktree.create' "${TEST_LOG}" || true)" -eq 0 ]
+    [ "$(tail -n 1 "${TEST_LOG}")" = $'-s\tses_test\t'"${worktree}"$'\t' ]
+}
+
+@test "accepts the long session equals form" {
+    local worktree="${TEST_ROOT}/trees/session-tree"
+    export LIST_RESPONSE='[{"directory":"'"${worktree}"'","strategy":"worktrunk"},{"directory":"'"${REPO_REAL}"'"}]'
+    export SESSION_RESPONSE='{"data":{"id":"ses_test","location":{"directory":"'"${worktree}"'"}}}'
+
+    run bash "${LAUNCHER}" "${TEST_ROOT}/repo" -w --session=ses_test
+
+    [ "${status}" -eq 0 ]
+    [ "$(tail -n 1 "${TEST_LOG}")" = $'--session=ses_test\t'"${worktree}"$'\t' ]
+}
+
+@test "rejects a named worktree that conflicts with the session" {
+    local worktree="${TEST_ROOT}/trees/session-tree"
+    export LIST_RESPONSE='[{"directory":"'"${worktree}"'","strategy":"worktrunk"},{"directory":"'"${REPO_REAL}"'"}]'
+    export SESSION_RESPONSE='{"data":{"id":"ses_test","location":{"directory":"'"${worktree}"'"}}}'
+
+    run bash "${LAUNCHER}" "${TEST_ROOT}/repo" -w other-tree -s ses_test
+
+    [ "${status}" -eq 2 ]
+    [[ "${output}" == *"belongs to worktree session-tree"* ]]
+    [ "$(grep -c 'v2.worktree.create' "${TEST_LOG}" || true)" -eq 0 ]
+}
+
+@test "rejects a session whose worktree no longer exists" {
+    local worktree="${TEST_ROOT}/trees/missing-tree"
+    export LIST_RESPONSE='[{"directory":"'"${REPO_REAL}"'"}]'
+    export SESSION_RESPONSE='{"data":{"id":"ses_test","location":{"directory":"'"${worktree}"'"}}}'
+
+    run bash "${LAUNCHER}" "${TEST_ROOT}/repo" -w -s ses_test
+
+    [ "${status}" -eq 2 ]
+    [[ "${output}" == *"no longer exists"* ]]
+    [ "$(grep -c 'v2.worktree.create' "${TEST_LOG}" || true)" -eq 0 ]
+}
+
+@test "routes Zsh calls through the local launcher" {
+    local home="${TEST_ROOT}/home"
+    mkdir -p "${home}/.local/bin"
+    cat >"${home}/.local/bin/opencode2" <<'EOF'
+#!/usr/bin/env bash
+printf 'local launcher\n'
+EOF
+    chmod +x "${home}/.local/bin/opencode2"
+
+    run env HOME="${home}" PATH="${TEST_BIN}:/usr/bin:/bin" /bin/zsh -dfc \
+        "source '${BATS_TEST_DIRNAME}/../home/dot_config/zsh/autoload/functions.zsh'; whence -w opencode2; opencode2"
+
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'opencode2: function\nlocal launcher' ]
+}


### PR DESCRIPTION
## TL;DR

OpenCode lacked named worktree startup, session affinity, safe cleanup, and visible checkout context. Native worktree APIs now use Worktrunk for lifecycle operations, while the launcher and TUI add the missing workflow.

**Files to review (14, +970 / -10):**

| File | Why |
|---|---|
| `home/dot_config/opencode/plugins/worktrunk/index.ts` *(start here)* | Registers Worktrunk and adds session movement and isolated task execution. |
| `home/dot_config/opencode/plugins/worktrunk/worktree.ts` | Converts OpenCode operations to validated Worktrunk commands and results. |
| `home/dot_local/bin/executable_opencode2` | Adds worktree flags, session affinity, and safe exit cleanup. |
| `home/dot_config/opencode/plugins/statusline/tui.tsx` | Shows checkout details in the prompt footer and sidebar. |
| `home/dot_config/worktrunk/config.toml` | Copies included ignored files before startup. |
| `tests/opencode2-worktree.bats` | Covers launcher startup, resume, conflict, and cleanup behavior. |
| `home/dot_config/opencode/plugins/{statusline,worktrunk}/*.test.ts` | Covers checkout formatting and Worktrunk boundary parsing. |

## How

Worktrunk owns worktree creation, inventory, hooks, and removal. OpenCode keeps session metadata, native location APIs, and TUI integration.

A shell launcher handles `-w` because plugins load after OpenCode parses startup arguments. The launcher removes only new, clean, integrated worktrees after OpenCode exits.

The `/worktree` command moves an active session without sending a model prompt. An isolated task tool runs independent work in separate Worktrunk worktrees.

## Reviewer notes

- **Cleanup stays conservative.** Dirty and unmerged worktrees remain available for recovery.
- **Paths stay aligned.** OpenCode and Worktrunk use `<repo>/.worktrees/<branch>`.
- **Sidebar stays automatic.** OpenCode shows it when terminal width permits.

## Tests

- `bats tests/opencode2-worktree.bats`
- `npm test` in `home/dot_config/opencode`
- ShellCheck and shell syntax checks
- Bun builds for the Worktrunk and status-line plugins
- Real create, resume, move, copy, cleanup, and sidebar checks

## Links

- https://github.com/anomalyco/opencode/issues/48272
